### PR TITLE
 radMul optimise interest calc

### DIFF
--- a/src/contracts/AssetLogic.sol
+++ b/src/contracts/AssetLogic.sol
@@ -54,12 +54,8 @@ library AssetLogic {
     return shares.toAssetsDown(asset.totalAssets(), asset.totalShares());
   }
 
-  // todo carry out mul in rad for precision
   function getInterestRate(Asset storage asset) external view returns (uint256) {
-    return
-      asset.baseBorrowRate.percentMul(
-        PercentageMath.PERCENTAGE_FACTOR + asset.riskPremiumRad.radToBps()
-      );
+    return asset.baseBorrowRate.radMul(WadRayMath.RAD + asset.riskPremiumRad);
   }
 
   function updateBorrowRate(
@@ -113,9 +109,7 @@ library AssetLogic {
     uint256 cumulatedBaseDebt = asset.baseDebt.rayMul(cumulatedBaseInterest);
 
     // accrue premium interest on the accrued base interest
-    asset.outstandingPremium += (cumulatedBaseDebt - existingBaseDebt).percentMul(
-      asset.riskPremiumRad.radToBps()
-    );
+    asset.outstandingPremium += (cumulatedBaseDebt - existingBaseDebt).radMul(asset.riskPremiumRad);
     asset.baseDebt = cumulatedBaseDebt;
     asset.baseBorrowIndex = nextBaseBorrowIndex;
     asset.lastUpdateTimestamp = block.timestamp;

--- a/src/contracts/SpokeDataLogic.sol
+++ b/src/contracts/SpokeDataLogic.sol
@@ -24,10 +24,7 @@ library SpokeDataLogic {
       spoke.baseBorrowIndex
     );
 
-    // todo carry out multiplication in rad (radMul) for precision
-    spoke.outstandingPremium += (cumulatedBaseDebt - existingBaseDebt).percentMul(
-      spoke.riskPremiumRad.radToBps()
-    );
+    spoke.outstandingPremium += (cumulatedBaseDebt - existingBaseDebt).radMul(spoke.riskPremiumRad);
     spoke.baseDebt = cumulatedBaseDebt;
     spoke.baseBorrowIndex = nextBaseBorrowIndex;
     spoke.lastUpdateTimestamp = block.timestamp;

--- a/src/contracts/WadRayMath.sol
+++ b/src/contracts/WadRayMath.sol
@@ -97,6 +97,42 @@ library WadRayMath {
   }
 
   /**
+   * @notice Multiplies two rad, rounding half up to the nearest rad
+   * @dev assembly optimized for improved gas savings, see https://twitter.com/transmissions11/status/1451131036377571328
+   * @param a Rad
+   * @param b Rad
+   * @return c = a radMul b
+   */
+  function radMul(uint256 a, uint256 b) internal pure returns (uint256 c) {
+    // to avoid overflow, a <= (type(uint256).max - HALF_RAD) / b
+    assembly {
+      if iszero(or(iszero(b), iszero(gt(a, div(sub(not(0), HALF_RAD), b))))) {
+        revert(0, 0)
+      }
+
+      c := div(add(mul(a, b), HALF_RAD), RAD)
+    }
+  }
+
+  /**
+   * @notice Divides two rad, rounding half up to the nearest rad
+   * @dev assembly optimized for improved gas savings, see https://twitter.com/transmissions11/status/1451131036377571328
+   * @param a Rad
+   * @param b Rad
+   * @return c = a radDiv b
+   */
+  function radDiv(uint256 a, uint256 b) internal pure returns (uint256 c) {
+    // to avoid overflow, a <= (type(uint256).max - halfB) / RAD
+    assembly {
+      if or(iszero(b), iszero(iszero(gt(a, div(sub(not(0), div(b, 2)), RAD))))) {
+        revert(0, 0)
+      }
+
+      c := div(add(mul(a, RAD), div(b, 2)), b)
+    }
+  }
+
+  /**
    * @dev Casts ray down to wad
    * @dev assembly optimized for improved gas savings, see https://twitter.com/transmissions11/status/1451131036377571328
    * @param a Ray
@@ -194,7 +230,6 @@ library WadRayMath {
   }
 
   function bpsToRad(uint256 a) internal pure returns (uint256) {
-    if (a > 100_00) a = 100_00;
     return (a * RAD) / 100_00;
   }
 
@@ -203,7 +238,6 @@ library WadRayMath {
   }
 
   function bpsToRay(uint256 a) internal pure returns (uint256) {
-    if (a > 100_00) a = 100_00;
     return (a * RAY) / 100_00;
   }
 

--- a/src/libraries/types/DataTypes.sol
+++ b/src/libraries/types/DataTypes.sol
@@ -21,6 +21,6 @@ library DataTypes {
   struct AssetConfig {
     uint256 decimals;
     bool active; // TODO: frozen, paused
-    address irStrategy;
+    address irStrategy; // todo use interface
   }
 }

--- a/tests/mocks/WadRayMathWrapper.sol
+++ b/tests/mocks/WadRayMathWrapper.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import {WadRayMath} from 'src/contracts/WadRayMath.sol';
+
+contract WadRayMathWrapper {
+  function WAD() public pure returns (uint256) {
+    return WadRayMath.WAD;
+  }
+
+  function RAY() public pure returns (uint256) {
+    return WadRayMath.RAY;
+  }
+
+  function RAD() public pure returns (uint256) {
+    return WadRayMath.RAD;
+  }
+
+  function HALF_RAY() public pure returns (uint256) {
+    return WadRayMath.HALF_RAY;
+  }
+
+  function HALF_RAD() public pure returns (uint256) {
+    return WadRayMath.HALF_RAD;
+  }
+
+  function HALF_WAD() public pure returns (uint256) {
+    return WadRayMath.HALF_WAD;
+  }
+
+  function WAD_RAY_RATIO() public pure returns (uint256) {
+    return WadRayMath.WAD_RAY_RATIO;
+  }
+
+  function RAD_RAY_RATIO() public pure returns (uint256) {
+    return WadRayMath.RAD_RAY_RATIO;
+  }
+
+  function wadMul(uint256 a, uint256 b) public pure returns (uint256) {
+    return WadRayMath.wadMul(a, b);
+  }
+
+  function wadDiv(uint256 a, uint256 b) public pure returns (uint256) {
+    return WadRayMath.wadDiv(a, b);
+  }
+
+  function rayMul(uint256 a, uint256 b) public pure returns (uint256) {
+    return WadRayMath.rayMul(a, b);
+  }
+
+  function rayDiv(uint256 a, uint256 b) public pure returns (uint256) {
+    return WadRayMath.rayDiv(a, b);
+  }
+
+  function radMul(uint256 a, uint256 b) public pure returns (uint256) {
+    return WadRayMath.radMul(a, b);
+  }
+
+  function radDiv(uint256 a, uint256 b) public pure returns (uint256) {
+    return WadRayMath.radDiv(a, b);
+  }
+
+  function rayToWad(uint256 a) public pure returns (uint256) {
+    return WadRayMath.rayToWad(a);
+  }
+
+  function wadToRay(uint256 a) public pure returns (uint256) {
+    return WadRayMath.wadToRay(a);
+  }
+
+  function rayToRad(uint256 a) public pure returns (uint256) {
+    return WadRayMath.rayToRad(a);
+  }
+
+  function radToRay(uint256 a) public pure returns (uint256) {
+    return WadRayMath.radToRay(a);
+  }
+
+  function toRad(uint256 a) public pure returns (uint256) {
+    return WadRayMath.toRad(a);
+  }
+
+  function fromRad(uint256 a) public pure returns (uint256) {
+    return WadRayMath.fromRad(a);
+  }
+
+  function bpsToRad(uint256 a) internal pure returns (uint256) {
+    return WadRayMath.bpsToRad(a);
+  }
+
+  function radToBps(uint256 a) internal pure returns (uint256) {
+    return WadRayMath.radToBps(a);
+  }
+
+  function bpsToRay(uint256 a) internal pure returns (uint256) {
+    return WadRayMath.bpsToRay(a);
+  }
+
+  function rayToBps(uint256 a) internal pure returns (uint256) {
+    return WadRayMath.rayToBps(a);
+  }
+}

--- a/tests/unit/WadRayMath.t.sol
+++ b/tests/unit/WadRayMath.t.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {Test} from 'forge-std/Test.sol';
+import {WadRayMathWrapper} from 'tests/mocks/WadRayMathWrapper.sol';
+
+contract WadRayMathTests is Test {
+  WadRayMathWrapper internal w;
+
+  function setUp() public {
+    w = new WadRayMathWrapper();
+  }
+
+  function test_constants() public view {
+    assertEq(w.WAD(), 1e18, 'wad');
+    assertEq(w.HALF_WAD(), 1e18 / 2, 'half wad');
+    assertEq(w.RAY(), 1e27, 'ray');
+    assertEq(w.HALF_RAY(), 1e27 / 2, 'half_ray');
+    assertEq(w.RAD(), 1e8, 'ray');
+    assertEq(w.HALF_RAD(), 1e8 / 2, 'half_rad');
+  }
+
+  function test_wadMul_edge() public view {
+    assertEq(w.wadMul(0, 1e18), 0);
+    assertEq(w.wadMul(1e18, 0), 0);
+    assertEq(w.wadMul(0, 0), 0);
+  }
+
+  function test_wadMul_fuzzing(uint256 a, uint256 b) public {
+    if ((b == 0 || (a > (type(uint256).max - w.HALF_WAD()) / b) == false) == false) {
+      vm.expectRevert();
+      w.wadMul(a, b);
+      return;
+    }
+
+    assertEq(w.wadMul(a, b), ((a * b) + w.HALF_WAD()) / w.WAD());
+  }
+
+  function test_wadDiv_fuzzing(uint256 a, uint256 b) public {
+    if ((b == 0) || (((a > ((type(uint256).max - b / 2) / w.WAD())) == false) == false)) {
+      vm.expectRevert();
+      w.wadDiv(a, b);
+      return;
+    }
+
+    assertEq(w.wadDiv(a, b), ((a * w.WAD()) + (b / 2)) / b);
+  }
+
+  function test_wadMul() public view {
+    assertEq(w.wadMul(2.5e18, 0.5e18), 1.25e18);
+    assertEq(w.wadMul(412.2e18, 1e18), 412.2e18);
+    assertEq(w.wadMul(6e18, 2e18), 12e18);
+  }
+
+  function test_rayMul() public view {
+    assertEq(w.rayMul(2.5e27, 0.5e27), 1.25e27);
+    assertEq(w.rayMul(412.2e27, 1e27), 412.2e27);
+    assertEq(w.rayMul(6e27, 2e27), 12e27);
+  }
+
+  function test_wadDiv() public view {
+    assertEq(w.wadDiv(2.5e18, 0.5e18), 5e18);
+    assertEq(w.wadDiv(412.2e18, 1e18), 412.2e18);
+    assertEq(w.wadDiv(8.745e18, 0.67e18), 13.052238805970149254e18);
+    assertEq(w.wadDiv(6e18, 2e18), 3e18);
+  }
+
+  function test_rayDiv() public view {
+    assertEq(w.rayDiv(2.5e27, 0.5e27), 5e27);
+    assertEq(w.rayDiv(412.2e27, 1e27), 412.2e27);
+    assertEq(w.rayDiv(8.745e27, 0.67e27), 13.052238805970149253731343284e27);
+    assertEq(w.rayDiv(6e27, 2e27), 3e27);
+  }
+
+  function test_wadToRay() public view {
+    assertEq(w.wadToRay(1e18), 1e27);
+    assertEq(w.wadToRay(412.2e18), 412.2e27);
+    assertEq(w.wadToRay(0), 0);
+  }
+
+  function test_rayToWad() public view {
+    assertEq(w.rayToWad(1e27), 1e18);
+    assertEq(w.rayToWad(412.2e27), 412.2e18);
+    assertEq(w.rayToWad(0), 0);
+  }
+
+  function test_wadToRay_fuzz(uint256 a) public {
+    uint256 b;
+    bool safetyCheck;
+    unchecked {
+      b = a * w.WAD_RAY_RATIO();
+      safetyCheck = b / w.WAD_RAY_RATIO() == a;
+    }
+    if (!safetyCheck) {
+      vm.expectRevert();
+      w.wadToRay(a);
+    } else {
+      assertEq(w.wadToRay(a), a * w.WAD_RAY_RATIO());
+      assertEq(w.wadToRay(a), b);
+    }
+  }
+
+  function test_rayToWad_fuzz(uint256 a) public view {
+    uint256 b;
+    uint256 remainder;
+    bool roundHalf;
+    unchecked {
+      b = a / w.WAD_RAY_RATIO();
+      remainder = a % w.WAD_RAY_RATIO();
+      roundHalf = remainder < w.WAD_RAY_RATIO() / 2;
+    }
+    if (!roundHalf) {
+      assertEq(w.rayToWad(a), (a / w.WAD_RAY_RATIO()) + 1);
+      assertEq(w.rayToWad(a), b + 1);
+    } else {
+      assertEq(w.rayToWad(a), a / w.WAD_RAY_RATIO());
+      assertEq(w.rayToWad(a), b);
+    }
+  }
+
+  function test_radMul_fuzzing(uint256 a, uint256 b) public {
+    if ((b == 0 || (a > (type(uint256).max - w.HALF_RAD()) / b) == false) == false) {
+      vm.expectRevert();
+      w.radMul(a, b);
+      return;
+    }
+
+    assertEq(w.radMul(a, b), ((a * b) + w.HALF_RAD()) / w.RAD());
+  }
+
+  function test_radDiv_fuzzing(uint256 a, uint256 b) public {
+    if ((b == 0) || (((a > ((type(uint256).max - b / 2) / w.RAD())) == false) == false)) {
+      vm.expectRevert();
+      w.radDiv(a, b);
+      return;
+    }
+
+    assertEq(w.radDiv(a, b), ((a * w.RAD()) + (b / 2)) / b);
+  }
+}


### PR DESCRIPTION
should not overflow since we're only adding 4 more digits of precision

to merge after analysis on max allowed precision for riskPremium values is revisited based on new algorithm 
https://www.notion.so/aave/Incremental-Weighted-Average-Usage-1469d63a22de80d3aebdedae4de6deb2?pvs=4

we may switch to wad