### PR TITLE
Fix User RP Getter

### DIFF
--- a/src/contracts/LiquidityHub.sol
+++ b/src/contracts/LiquidityHub.sol
@@ -347,11 +347,19 @@ contract LiquidityHub is ILiquidityHub {
     return cumulatedBaseDebt + cumulatedOutstandingPremium;
   }
 
-  function getSuppliedAmount(uint256 assetId, address spoke) external view returns (uint256) {
+  function getAssetSuppliedAmount(uint256 assetId) external view returns (uint256) {
+    return _assets[assetId].convertToAssetsDown(_assets[assetId].suppliedShares);
+  }
+
+  function getAssetSuppliedShares(uint256 assetId) external view returns (uint256) {
+    return _assets[assetId].suppliedShares;
+  }
+
+  function getSpokeSuppliedAmount(uint256 assetId, address spoke) external view returns (uint256) {
     return _assets[assetId].convertToAssetsDown(_spokes[assetId][spoke].suppliedShares);
   }
 
-  function getSuppliedShares(uint256 assetId, address spoke) external view returns (uint256) {
+  function getSpokeSuppliedShares(uint256 assetId, address spoke) external view returns (uint256) {
     return _spokes[assetId][spoke].suppliedShares;
   }
 

--- a/src/contracts/Spoke.sol
+++ b/src/contracts/Spoke.sol
@@ -107,7 +107,19 @@ contract Spoke is ISpoke {
     return cumulatedBaseDebt + cumulatedOutstandingPremium;
   }
 
-  function getSuppliedAmount(uint256 reserveId, address user) external view returns (uint256) {
+  function getReserveSuppliedAmount(uint256 reserveId) external view returns (uint256) {
+    return
+      liquidityHub.convertToAssets(
+        _reserves[reserveId].assetId,
+        _reserves[reserveId].suppliedShares
+      );
+  }
+
+  function getReserveSuppliedShares(uint256 reserveId) external view returns (uint256) {
+    return _reserves[reserveId].suppliedShares;
+  }
+
+  function getUserSuppliedAmount(uint256 reserveId, address user) external view returns (uint256) {
     return
       liquidityHub.convertToAssets(
         _reserves[reserveId].assetId,
@@ -115,7 +127,7 @@ contract Spoke is ISpoke {
       );
   }
 
-  function getSuppliedShares(uint256 reserveId, address user) external view returns (uint256) {
+  function getUserSuppliedShares(uint256 reserveId, address user) external view returns (uint256) {
     return _users[user][reserveId].suppliedShares;
   }
 
@@ -467,7 +479,7 @@ contract Spoke is ISpoke {
     }
 
     if (collateralValue == 0) return 0;
-    return newUserRiskPremium / collateralValue;
+    return (newUserRiskPremium / collateralValue).rayify();
   }
 
   /// @dev It's assumed interest has been accrued before this function call.
@@ -491,8 +503,8 @@ contract Spoke is ISpoke {
 
     uint256 newUserDebt = baseDebtChange > 0
       ? existingUserDebt + uint256(baseDebtChange) // debt added
-      : // force underflow: only possible when user takes repays amount more than net drawn
-      existingUserDebt - uint256(-baseDebtChange); // debt restored
+      // force underflow: only possible when user takes repays amount more than net drawn
+      : existingUserDebt - uint256(-baseDebtChange); // debt restored
 
     (uint256 newReserveRiskPremium, uint256 newReserveDebt) = MathUtils.addToWeightedAverage(
       reserveRiskPremiumWithoutCurrent,
@@ -506,6 +518,8 @@ contract Spoke is ISpoke {
 
     reserve.riskPremium = newReserveRiskPremium;
     user.riskPremium = newUserRiskPremium;
+
+    return newReserveRiskPremium;
   }
 
   function _validateSetUsingAsCollateral(

--- a/src/interfaces/ILiquidityHub.sol
+++ b/src/interfaces/ILiquidityHub.sol
@@ -87,10 +87,13 @@ interface ILiquidityHub {
   function getSpokeCumulativeDebt(uint256 assetId, address spoke) external view returns (uint256);
   function getAssetDebt(uint256 assetId) external view returns (uint256, uint256);
   function getAssetCumulativeDebt(uint256 assetId) external view returns (uint256);
-  function getSuppliedAmount(uint256 assetId, address spoke) external view returns (uint256);
-  function getSuppliedShares(uint256 assetId, address spoke) external view returns (uint256);
   function getAssetRiskPremium(uint256 assetId) external view returns (uint256);
   function getSpokeRiskPremium(uint256 assetId, address spoke) external view returns (uint256);
+
+  function getAssetSuppliedAmount(uint256 assetId) external view returns (uint256);
+  function getAssetSuppliedShares(uint256 assetId) external view returns (uint256);
+  function getSpokeSuppliedAmount(uint256 assetId, address spoke) external view returns (uint256);
+  function getSpokeSuppliedShares(uint256 assetId, address spoke) external view returns (uint256);
 
   // todo: remove explicit rounding
   function convertToAssetsUp(uint256 assetId, uint256 shares) external view returns (uint256);

--- a/src/interfaces/ISpoke.sol
+++ b/src/interfaces/ISpoke.sol
@@ -31,6 +31,9 @@ interface ISpoke {
   function getReserveCumulativeDebt(uint256 reserveId) external view returns (uint256);
   function getUserRiskPremium(address user) external view returns (uint256);
   function getReserveRiskPremium(uint256 reserveId) external view returns (uint256);
-  function getSuppliedAmount(uint256 reserveId, address user) external view returns (uint256);
-  function getSuppliedShares(uint256 reserveId, address user) external view returns (uint256);
+
+  function getReserveSuppliedAmount(uint256 reserveId) external view returns (uint256);
+  function getReserveSuppliedShares(uint256 reserveId) external view returns (uint256);
+  function getUserSuppliedAmount(uint256 reserveId, address user) external view returns (uint256);
+  function getUserSuppliedShares(uint256 reserveId, address user) external view returns (uint256);
 }


### PR DESCRIPTION
User RP getter was not exactly correct, because the only up-to-date user RP is stored in that user's last reserve in the internal accounting. 

This fix changes to have User RP calculated on the fly and returned.

EDIT: However, we don't want user rp to be calculated on the fly and returned, we in fact do want to fetch the latest one stored (because user RP should be unchanging between user actions)

Closes #197 