### PR TITLE
KeyValueList optimisations 

### DIFF
--- a/snapshots/Spoke.Getters.json
+++ b/snapshots/Spoke.Getters.json
@@ -1,7 +1,7 @@
 {
-  "getUserAccountData: supplies: 0, borrows: 0": "32889",
-  "getUserAccountData: supplies: 1, borrows: 0": "27559",
-  "getUserAccountData: supplies: 2, borrows: 0": "35445",
-  "getUserAccountData: supplies: 2, borrows: 1": "34347",
-  "getUserAccountData: supplies: 2, borrows: 2": "40722"
+  "getUserAccountData: supplies: 0, borrows: 0": "32828",
+  "getUserAccountData: supplies: 1, borrows: 0": "27337",
+  "getUserAccountData: supplies: 2, borrows: 0": "35101",
+  "getUserAccountData: supplies: 2, borrows: 1": "33716",
+  "getUserAccountData: supplies: 2, borrows: 2": "39804"
 }

--- a/snapshots/Spoke.Operations.json
+++ b/snapshots/Spoke.Operations.json
@@ -1,13 +1,13 @@
 {
-  "borrow": "416552",
-  "repay: full": "270984",
-  "repay: partial": "271211",
-  "supply: 0 debt, collateralDisabled": "363244",
-  "supply: 0 debt, collateralEnabled": "383823",
-  "supply: 1 debt": "438862",
-  "supply: 2 debt": "511698",
-  "supply: 3 debt": "582314",
+  "borrow": "416043",
+  "repay: full": "270806",
+  "repay: partial": "270804",
+  "supply: 0 debt, collateralDisabled": "363183",
+  "supply: 0 debt, collateralEnabled": "383601",
+  "supply: 1 debt": "438353",
+  "supply: 2 debt": "510780",
+  "supply: 3 debt": "581561",
   "usingAsCollateral": "50151",
-  "withdraw: full": "222680",
-  "withdraw: partial": "212536"
+  "withdraw: full": "222458",
+  "withdraw: partial": "212314"
 }

--- a/src/contracts/KeyValueListInMemory.sol
+++ b/src/contracts/KeyValueListInMemory.sol
@@ -22,9 +22,17 @@ library KeyValueListInMemory {
     uint256[] _inner;
   }
 
-  function init(uint256 size) internal pure returns (List memory) {
-    // opt: cheaper to allocate memory w/o zeroing out: https://github.com/Vectorized/solady/blob/main/src/utils/DynamicArrayLib.sol#L34-L42
-    return List(new uint256[](size));
+  function init(uint256 size) internal pure returns (List memory list) {
+    // @dev allocate memory without zeroing out slots
+    assembly {
+      // revert is size > 2 ** 32, load array at fmp
+      let inner := or(sub(0, shr(32, size)), mload(0x40))
+      mstore(inner, size)
+      // increment fmp location
+      list := add(add(inner, 0x20), shl(5, size))
+      mstore(list, inner)
+      mstore(0x40, add(list, 0x20))
+    }
   }
 
   function length(List memory self) internal pure returns (uint256) {
@@ -48,23 +56,31 @@ library KeyValueListInMemory {
   }
 
   // @dev key, value < ceiling checks are expected to be done before packing
-  function pack(uint256 key, uint256 value) internal pure returns (uint256) {
-    return (key << _KEY_SHIFT) | value;
+  function pack(uint256 key, uint256 value) internal pure returns (uint256 packed) {
+    assembly ('memory-safe') {
+      packed := or(shl(sub(256, _MAX_KEY_BITS), key), value)
+    }
   }
 
-  function unpackKey(uint256 data) internal pure returns (uint256) {
-    return data >> _KEY_SHIFT;
+  function unpackKey(uint256 data) internal pure returns (uint256 key) {
+    assembly ('memory-safe') {
+      key := shr(sub(256, _MAX_KEY_BITS), data)
+    }
   }
 
-  function unpackValue(uint256 data) internal pure returns (uint256) {
-    return data & ((1 << _KEY_SHIFT) - 1);
+  function unpackValue(uint256 data) internal pure returns (uint256 value) {
+    assembly ('memory-safe') {
+      value := and(data, sub(shl(_MAX_VALUE_BITS, 1), 1))
+    }
   }
 
   function unpack(uint256 data) internal pure returns (uint256, uint256) {
     return (unpackKey(data), unpackValue(data));
   }
 
-  function ltComparator(uint256 a, uint256 b) internal pure returns (bool) {
-    return a < b;
+  function ltComparator(uint256 a, uint256 b) internal pure returns (bool res) {
+    assembly ('memory-safe') {
+      res := lt(a, b)
+    }
   }
 }


### PR DESCRIPTION
use native array over struct packing to avoid solidity allocating 2d dynamic mem 
compare with struct native packing 

[DO NOT MERGE]