### PR TITLE
Extend prototype scenario tests 

### DIFF
--- a/tests/ts/prototype/core.ts
+++ b/tests/ts/prototype/core.ts
@@ -22,7 +22,7 @@ let userIdCounter = 0n;
 
 let currentTime = 1n;
 
-const OFFSET_UNITS = 10n ** 6n;
+export const OFFSET_UNITS = 10n ** 6n;
 
 // type/token transfers to differentiate supplied/debt shares
 // notify is unneeded since prototype assumes one asset on hub
@@ -112,8 +112,10 @@ export class LiquidityHub {
   }
 
   withdraw(amount: bigint, spoke: Spoke) {
-    const suppliedShares = this.toSupplyShares(amount, Rounding.CEIL);
-
+    // to withdraw all liquidity use MAX_UINT
+    amount = amount > this.availableLiquidity ? this.availableLiquidity : amount;
+    let suppliedShares = this.toSupplyShares(amount, Rounding.CEIL);
+    
     this.suppliedShares -= suppliedShares;
     this.availableLiquidity -= amount;
 
@@ -267,6 +269,9 @@ export class Spoke {
     const user = this.getUser(who);
 
     this.hub.accrue();
+    if (amount == MAX_UINT) {
+      amount = who.getSuppliedBalance();
+    }
     const suppliedShares = this.hub.withdraw(amount, this);
 
     this.suppliedShares -= suppliedShares;
@@ -551,6 +556,10 @@ export class User {
 
   getSuppliedBalance() {
     return this.hub.toSupplyAssets(this.suppliedShares);
+  }
+
+  getSuppliedShares() {
+    return this.suppliedShares;
   }
 
   log(spoke = false, hub = false) {

--- a/tests/ts/prototype/multi-scenario.t.ts
+++ b/tests/ts/prototype/multi-scenario.t.ts
@@ -1,4 +1,4 @@
-import {LiquidityHub, Spoke, User, skip} from './core';
+import {LiquidityHub, Spoke, User, skip, OFFSET_UNITS} from './core';
 import {absDiff, f, maxAbsDiff, p, PRECISION, MAX_UINT} from './utils';
 
 const tests: {name: string; test: () => void}[] = [];
@@ -121,6 +121,46 @@ addTest('Scenario3', () => {
 
   runAmountInvariants();
   assert_zeroRemainingDebt();
+});
+
+// Test Scenario 4 - withdraw
+// t0: alice supply/borrow
+// 
+addTest('Scenario4', () => {
+  const [alice, bob, charlie] = setUp();
+
+  const amount1 = p('10000');
+  const amount2 = p('200');
+  const amount3 = p('500');
+  const amount4 = p('800');
+
+  alice.supply(amount1);
+  
+  skip();
+  bob.borrow(amount2);
+  bob.supply(amount3);
+
+  skip();
+  charlie.supply(amount3);
+  charlie.borrow(amount2);
+
+  skip();
+  alice.withdraw(MAX_UINT);
+
+  skip();
+  bob.withdraw(MAX_UINT);
+
+  skip();
+  charlie.repay(MAX_UINT);
+  bob.repay(MAX_UINT);
+
+  skip();
+  charlie.withdraw(MAX_UINT);
+  bob.withdraw(MAX_UINT);
+  alice.withdraw(MAX_UINT);
+
+  runAmountInvariants();
+  assert_zeroRemainingSuppliedShares();
 });
 
 // run all tests
@@ -285,6 +325,28 @@ function invariant_sumOfSuppliedShares() {
   }
 
   handleInvariantFailure(fail, 'invariant_sumOfSuppliedShares');
+}
+
+function assert_zeroRemainingSuppliedShares() {
+  const hubSuppliedShares = hub.suppliedShares;
+  const spokeSuppliedShares = spokes.reduce((sum, spoke) => sum + spoke.suppliedShares, 0n);
+  const userSuppliedShares = users.reduce((sum, user) => sum + user.suppliedShares, 0n);
+  let fail = false;
+  const supplySharePrecision = hub.toSupplyShares(OFFSET_UNITS);
+
+  if (hubSuppliedShares > supplySharePrecision || spokeSuppliedShares > supplySharePrecision || userSuppliedShares > supplySharePrecision) {
+    console.error(
+      'non zero supplied shares',
+      f(hubSuppliedShares),
+      f(spokeSuppliedShares),
+      f(userSuppliedShares),
+      f(supplySharePrecision)
+    );
+    fail = true;
+    throw new Error('assert_zeroRemainingSuppliedShares failed');
+  }
+
+  handleInvariantFailure(fail, 'assert_zeroRemainingSuppliedShares');
 }
 
 function invariant_positivePremiumDebt() {


### PR DESCRIPTION
- extend scenario tests to allow multiple scenario setups
- adjust debt rounding so that baseDrawnShares is restored to 0 after repay 