### PR TITLE
feat: optimise risk premium calc implementation

### DIFF
--- a/snapshots/Spoke.Getters.json
+++ b/snapshots/Spoke.Getters.json
@@ -1,7 +1,7 @@
 {
-  "getUserAccountData: supplies: 0, borrows: 0": "23895",
-  "getUserAccountData: supplies: 1, borrows: 0": "59023",
-  "getUserAccountData: supplies: 2, borrows: 0": "91701",
-  "getUserAccountData: supplies: 2, borrows: 1": "46704",
-  "getUserAccountData: supplies: 2, borrows: 2": "56682"
+  "getUserAccountData: supplies: 0, borrows: 0": "30920",
+  "getUserAccountData: supplies: 1, borrows: 0": "47413",
+  "getUserAccountData: supplies: 2, borrows: 0": "61176",
+  "getUserAccountData: supplies: 2, borrows: 1": "30199",
+  "getUserAccountData: supplies: 2, borrows: 2": "37350"
 }

--- a/snapshots/Spoke.Operations.json
+++ b/snapshots/Spoke.Operations.json
@@ -1,13 +1,13 @@
 {
-  "borrow": "513780",
-  "repay: full": "241742",
-  "repay: partial": "324624",
+  "borrow": "494144",
+  "repay: full": "223785",
+  "repay: partial": "304988",
   "supply: 0 debt, collateralDisabled": "170201",
   "supply: 0 debt, collateralEnabled": "170177",
   "supply: 1 debt": "170225",
   "supply: 2 debt": "170236",
   "supply: 3 debt": "170189",
   "usingAsCollateral": "50661",
-  "withdraw: full": "229667",
-  "withdraw: partial": "234478"
+  "withdraw: full": "224089",
+  "withdraw: partial": "228867"
 }

--- a/src/contracts/Spoke.sol
+++ b/src/contracts/Spoke.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 // libraries
 import {WadRayMath} from 'src/libraries/math/WadRayMath.sol';
 import {PercentageMath} from 'src/libraries/math/PercentageMath.sol';
-import {KeyValueListInMemory} from 'src/libraries/helpers/KeyValueListInMemory.sol';
+import {OrderedReserveRiskArray} from 'src/libraries/helpers/OrderedReserveRiskArray.sol';
 import {DataTypes} from 'src/libraries/types/DataTypes.sol';
 import {LiquidationLogic} from 'src/libraries/logic/LiquidationLogic.sol';
 
@@ -16,7 +16,7 @@ import {IPriceOracle} from 'src/interfaces/IPriceOracle.sol';
 contract Spoke is ISpoke {
   using WadRayMath for uint256;
   using PercentageMath for uint256;
-  using KeyValueListInMemory for KeyValueListInMemory.List;
+  using OrderedReserveRiskArray for DataTypes.ReserveRiskConfig[];
   using LiquidationLogic for DataTypes.LiquidationConfig;
 
   uint256 public constant HEALTH_FACTOR_LIQUIDATION_THRESHOLD = WadRayMath.WAD;
@@ -27,7 +27,7 @@ contract Spoke is ISpoke {
     internal _userPositions;
   mapping(uint256 reserveId => DataTypes.Reserve reserveData) internal _reserves;
   DataTypes.LiquidationConfig internal _liquidationConfig;
-  uint256[] public reservesList; // todo: rm, not needed
+  DataTypes.ReserveRiskConfig[] public reserveRiskConfigs; // sorted in ascending order by liquidityPremium
   uint256 public reserveCount;
 
   constructor(address hubAddress, address oracleAddress, uint256 closeFactorValue) {
@@ -62,7 +62,14 @@ contract Spoke is ISpoke {
     address asset = address(HUB.assetsList(assetId)); // will revert on invalid assetId
     uint256 reserveId = reserveCount++;
     // TODO: AccessControl
-    reservesList.push(reserveId);
+    reserveRiskConfigs.insert(
+      DataTypes.ReserveRiskConfig({
+        reserveId: reserveId,
+        assetId: assetId,
+        collateralFactor: config.collateralFactor,
+        liquidityPremium: config.liquidityPremium
+      })
+    );
     _reserves[reserveId] = DataTypes.Reserve({
       reserveId: reserveId,
       assetId: assetId,
@@ -99,6 +106,14 @@ contract Spoke is ISpoke {
     DataTypes.Reserve storage reserve = _reserves[reserveId];
     require(reserve.asset != address(0), InvalidReserve());
     // TODO: AccessControl
+    reserveRiskConfigs.update(
+      DataTypes.ReserveRiskConfig({
+        reserveId: reserveId,
+        assetId: reserve.assetId,
+        collateralFactor: config.collateralFactor,
+        liquidityPremium: config.liquidityPremium
+      })
+    );
     reserve.config = DataTypes.ReserveConfig({
       decimals: reserve.config.decimals, // decimals remains existing value
       active: config.active,
@@ -379,6 +394,7 @@ contract Spoke is ISpoke {
     (, , uint256 healthFactor, , ) = _calculateUserAccountData(user);
     return healthFactor;
   }
+
   function getReservePrice(uint256 reserveId) public view returns (uint256) {
     return oracle.getAssetPrice(_reserves[reserveId].assetId);
   }
@@ -584,126 +600,95 @@ contract Spoke is ISpoke {
   function _calculateUserAccountData(
     address userAddress
   ) internal view returns (uint256, uint256, uint256, uint256, uint256) {
-    DataTypes.CalculateUserAccountDataVars memory vars;
-    uint256 reservesListLength = reservesList.length;
+    uint256 reserveRiskConfigsLength = reserveRiskConfigs.length;
 
-    while (vars.reserveId < reservesListLength) {
-      DataTypes.UserPosition storage userPosition = _userPositions[userAddress][vars.reserveId];
+    uint256 totalDebtInBaseCurrency;
+    uint256[] memory userCollateralInBaseCurrency = new uint256[](reserveRiskConfigsLength);
+
+    uint256 totalCollateralInBaseCurrency;
+    uint256 avgCollateralFactor;
+
+    for (uint256 i = 0; i < reserveRiskConfigsLength; i += 1) {
+      DataTypes.ReserveRiskConfig storage reserveRiskConfig = reserveRiskConfigs[i];
+      DataTypes.UserPosition storage userPosition = _userPositions[userAddress][
+        reserveRiskConfig.reserveId
+      ];
 
       if (!_usingAsCollateralOrBorrowing(userPosition)) {
-        unchecked {
-          ++vars.reserveId;
-        }
         continue;
       }
-      DataTypes.Reserve memory reserve = _reserves[vars.reserveId];
-      vars.assetId = reserve.assetId;
 
-      vars.assetPrice = oracle.getAssetPrice(vars.assetId);
+      uint256 assetId = reserveRiskConfig.assetId;
+      uint256 assetPrice = oracle.getAssetPrice(assetId);
+      uint256 assetUnit;
       unchecked {
-        vars.assetUnit = 10 ** HUB.getAssetConfig(vars.assetId).decimals;
-      }
-
-      if (_usingAsCollateral(userPosition)) {
-        // @dev opt: this can be extracted by counting number of set bits in a supplied (only) bitmap saving one loop
-        unchecked {
-          ++vars.collateralReserveCount;
-        }
+        assetUnit = 10 ** HUB.getAssetConfig(assetId).decimals;
       }
 
       if (_isBorrowing(userPosition)) {
-        vars.totalDebtInBaseCurrency += _getUserDebtInBaseCurrency(
+        totalDebtInBaseCurrency += _getUserDebtInBaseCurrency(
           userPosition,
-          vars.assetId,
-          vars.assetPrice,
-          vars.assetUnit
+          assetId,
+          assetPrice,
+          assetUnit
         );
       }
 
-      unchecked {
-        ++vars.reserveId;
-      }
-    }
-
-    // @dev only allocate required memory at the cost of an extra loop
-    KeyValueListInMemory.List memory list = KeyValueListInMemory.init(vars.collateralReserveCount);
-    vars.i = 0;
-    vars.reserveId = 0;
-    while (vars.reserveId < reservesListLength) {
-      DataTypes.UserPosition storage userPosition = _userPositions[userAddress][vars.reserveId];
-      DataTypes.Reserve storage reserve = _reserves[vars.reserveId];
       if (_usingAsCollateral(userPosition)) {
-        vars.assetId = reserve.assetId;
-        vars.liquidityPremium = reserve.config.liquidityPremium;
-        vars.assetPrice = oracle.getAssetPrice(vars.assetId);
-        unchecked {
-          vars.assetUnit = 10 ** HUB.getAssetConfig(vars.assetId).decimals;
-        }
-        vars.userCollateralInBaseCurrency = _getUserBalanceInBaseCurrency(
+        userCollateralInBaseCurrency[i] += _getUserBalanceInBaseCurrency(
           userPosition,
-          vars.assetId,
-          vars.assetPrice,
-          vars.assetUnit
+          assetId,
+          assetPrice,
+          assetUnit
         );
 
-        vars.totalCollateralInBaseCurrency += vars.userCollateralInBaseCurrency;
-        list.add(vars.i, vars.liquidityPremium, vars.userCollateralInBaseCurrency);
-        vars.avgCollateralFactor +=
-          vars.userCollateralInBaseCurrency *
-          reserve.config.collateralFactor;
+        totalCollateralInBaseCurrency += userCollateralInBaseCurrency[i];
 
-        unchecked {
-          ++vars.i;
-        }
-      }
-
-      unchecked {
-        ++vars.reserveId;
+        avgCollateralFactor += userCollateralInBaseCurrency[i] * reserveRiskConfig.collateralFactor;
       }
     }
 
     // at this point avgCollateralFactor is a weighted sum of collateral scaled by collateralFactor
     // (avgCollateralFactor / totalCollateral) * totalCollateral can be simplified to avgCollateralFactor
     // strip BPS factor from result, because running avgCollateralFactor sum has been scaled by collateralFactor (in BPS) above
-    vars.healthFactor = vars.totalDebtInBaseCurrency == 0
+    uint256 healthFactor = totalDebtInBaseCurrency == 0
       ? type(uint256).max
-      : vars.avgCollateralFactor.wadDiv(vars.totalDebtInBaseCurrency).fromBps(); // HF of 1 -> 1e18
+      : avgCollateralFactor.wadDiv(totalDebtInBaseCurrency).fromBps(); // HF of 1 -> 1e18
 
     // divide by total collateral to get avg collateral factor in wad
-    vars.avgCollateralFactor = vars.totalCollateralInBaseCurrency == 0
+    avgCollateralFactor = totalCollateralInBaseCurrency == 0
       ? 0
-      : vars.avgCollateralFactor.wadDiv(vars.totalCollateralInBaseCurrency).fromBps();
+      : avgCollateralFactor.wadDiv(totalCollateralInBaseCurrency).fromBps();
 
-    vars.debtCounterInBaseCurrency = vars.totalDebtInBaseCurrency;
+    uint256 collateralCoveredInBaseCurrency;
+    uint256 userRiskPremium;
+    for (
+      uint256 i = 0;
+      i < reserveRiskConfigsLength && collateralCoveredInBaseCurrency < totalDebtInBaseCurrency;
+      i += 1
+    ) {
+      DataTypes.ReserveRiskConfig storage reserveRiskConfig = reserveRiskConfigs[i];
 
-    list.sortByKey(); // sort by liquidity premium
-    vars.i = 0;
-    // @dev from this point onwards, `collateralCounterInBaseCurrency` represents running collateral
-    // value used in risk premium, `debtCounterInBaseCurrency` represents running outstanding debt
-    while (vars.i < vars.collateralReserveCount && vars.debtCounterInBaseCurrency > 0) {
-      if (vars.debtCounterInBaseCurrency == 0) break;
-      (vars.liquidityPremium, vars.userCollateralInBaseCurrency) = list.get(vars.i);
-      if (vars.userCollateralInBaseCurrency > vars.debtCounterInBaseCurrency) {
-        vars.userCollateralInBaseCurrency = vars.debtCounterInBaseCurrency;
+      if (
+        collateralCoveredInBaseCurrency + userCollateralInBaseCurrency[i] > totalDebtInBaseCurrency
+      ) {
+        userCollateralInBaseCurrency[i] = totalDebtInBaseCurrency - collateralCoveredInBaseCurrency;
       }
-      vars.userRiskPremium += vars.userCollateralInBaseCurrency * vars.liquidityPremium;
-      vars.collateralCounterInBaseCurrency += vars.userCollateralInBaseCurrency;
-      vars.debtCounterInBaseCurrency -= vars.userCollateralInBaseCurrency;
-      unchecked {
-        ++vars.i;
-      }
+
+      userRiskPremium += userCollateralInBaseCurrency[i] * reserveRiskConfig.liquidityPremium;
+      collateralCoveredInBaseCurrency += userCollateralInBaseCurrency[i];
     }
 
-    if (vars.collateralCounterInBaseCurrency > 0) {
-      vars.userRiskPremium = vars.userRiskPremium / vars.collateralCounterInBaseCurrency;
+    if (collateralCoveredInBaseCurrency > 0) {
+      userRiskPremium = userRiskPremium / collateralCoveredInBaseCurrency;
     }
 
     return (
-      vars.userRiskPremium,
-      vars.avgCollateralFactor,
-      vars.healthFactor,
-      vars.totalCollateralInBaseCurrency,
-      vars.totalDebtInBaseCurrency
+      userRiskPremium,
+      avgCollateralFactor,
+      healthFactor,
+      totalCollateralInBaseCurrency,
+      totalDebtInBaseCurrency
     );
   }
 

--- a/src/interfaces/ISpoke.sol
+++ b/src/interfaces/ISpoke.sol
@@ -130,7 +130,7 @@ interface ISpoke {
   function getUserTotalDebt(uint256 reserveId, address user) external view returns (uint256);
   function getUsingAsCollateral(uint256 reserveId, address user) external view returns (bool);
   function reserveCount() external view returns (uint256);
-  function reservesList(uint256) external view returns (uint256);
+  function reserveRiskConfigs(uint256) external view returns (uint256,uint256,uint256,uint256);
   function HEALTH_FACTOR_LIQUIDATION_THRESHOLD() external view returns (uint256);
   function getVariableLiquidationBonus(
     uint256 reserveId,

--- a/src/libraries/helpers/OrderedReserveRiskArray.sol
+++ b/src/libraries/helpers/OrderedReserveRiskArray.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {DataTypes} from 'src/libraries/types/DataTypes.sol';
+
+library OrderedReserveRiskArray {
+  error ReserveNotFound(uint256 reserveId);
+
+  function insert(
+    DataTypes.ReserveRiskConfig[] storage array,
+    DataTypes.ReserveRiskConfig memory value
+  ) internal {
+    _insert(array, value, _upper_bound(array, value));
+  }
+
+  function update(
+    DataTypes.ReserveRiskConfig[] storage array,
+    DataTypes.ReserveRiskConfig memory value
+  ) internal {
+    _remove(array, _find(array, value));
+    _insert(array, value, _upper_bound(array, value));
+  }
+
+  function _upper_bound(
+    DataTypes.ReserveRiskConfig[] storage array,
+    DataTypes.ReserveRiskConfig memory value
+  ) private view returns (uint256) {
+    uint256 index = array.length;
+    while (index > 0 && array[index - 1].liquidityPremium > value.liquidityPremium) {
+      index -= 1;
+    }
+    return index;
+  }
+
+  function _find(
+    DataTypes.ReserveRiskConfig[] storage array,
+    DataTypes.ReserveRiskConfig memory value
+  ) private view returns (uint256) {
+    for (uint256 i = 0; i < array.length; i += 1) {
+      if (array[i].reserveId == value.reserveId) {
+        return i;
+      }
+    }
+
+    revert ReserveNotFound(value.reserveId);
+  }
+
+  function _insert(
+    DataTypes.ReserveRiskConfig[] storage array,
+    DataTypes.ReserveRiskConfig memory value,
+    uint256 index
+  ) private {
+    // insert value just to increase the length of the array
+    array.push(value);
+
+    for (uint256 i = array.length - 1; i > index; i -= 1) {
+      array[i] = array[i - 1];
+    }
+    array[index] = value;
+  }
+
+  function _remove(DataTypes.ReserveRiskConfig[] storage array, uint256 index) private {
+    uint256 length = array.length;
+    for (uint256 i = index; i < length - 1; i += 1) {
+      array[i] = array[i + 1];
+    }
+
+    array.pop();
+  }
+}

--- a/src/libraries/types/DataTypes.sol
+++ b/src/libraries/types/DataTypes.sol
@@ -79,6 +79,13 @@ library DataTypes {
     uint256 liquidityPremium; // BPS TODO: use smaller uint
   }
 
+  struct ReserveRiskConfig {
+    uint256 reserveId;
+    uint256 assetId;
+    uint256 collateralFactor;
+    uint256 liquidityPremium;
+  }
+
   struct UserPosition {
     bool usingAsCollateral;
     uint256 suppliedShares;
@@ -86,25 +93,6 @@ library DataTypes {
     uint256 premiumDrawnShares;
     uint256 premiumOffset;
     uint256 realizedPremium;
-  }
-
-  struct CalculateUserAccountDataVars {
-    uint256 i;
-    uint256 assetId;
-    uint256 assetPrice;
-    uint256 assetUnit;
-    uint256 reserveId;
-    uint256 reservePrice;
-    uint256 liquidityPremium;
-    uint256 collateralReserveCount;
-    uint256 userCollateralInBaseCurrency;
-    uint256 totalCollateralInBaseCurrency;
-    uint256 totalDebtInBaseCurrency;
-    uint256 debtCounterInBaseCurrency;
-    uint256 collateralCounterInBaseCurrency;
-    uint256 avgCollateralFactor;
-    uint256 userRiskPremium;
-    uint256 healthFactor;
   }
 
   struct LiquidationConfig {


### PR DESCRIPTION
Closes #141 

The main idea is to duplicate the Reserve struct fiels whch are used in the rp algorithm into a new array, which is always sorted by the liquidityPremium

- it results in less gas generally
- it allows us to further optimise storage (by packing things into the same slot)
- it passes all tests from #321 