### PR TITLE
Constants removal so contracts are self-contained

### DIFF
--- a/src/contracts/Hub.sol
+++ b/src/contracts/Hub.sol
@@ -13,7 +13,6 @@ import {WadRayMath} from 'src/libraries/math/WadRayMath.sol';
 import {SharesMath} from 'src/libraries/math/SharesMath.sol';
 import {PercentageMath} from 'src/libraries/math/PercentageMath.sol';
 import {MathUtils} from 'src/libraries/math/MathUtils.sol';
-import {Constants} from 'src/libraries/helpers/Constants.sol';
 
 import {IHubBase, IHub} from 'src/interfaces/IHub.sol';
 import {IAssetInterestRateStrategy} from 'src/interfaces/IAssetInterestRateStrategy.sol';
@@ -27,6 +26,11 @@ contract Hub is IHub, AccessManaged {
   using PercentageMath for uint256;
   using AssetLogic for Asset;
   using MathUtils for *;
+
+  /// @inheritdoc IHub
+  uint8 public constant MAX_ALLOWED_ASSET_DECIMALS = 18;
+  /// @inheritdoc IHub
+  uint56 public constant MAX_CAP = type(uint56).max;
 
   uint256 internal _assetCount;
   mapping(uint256 assetId => Asset assetData) internal _assets;
@@ -54,7 +58,7 @@ contract Hub is IHub, AccessManaged {
       underlying != address(0) && feeReceiver != address(0) && irStrategy != address(0),
       InvalidAddress()
     );
-    require(decimals <= Constants.MAX_ALLOWED_ASSET_DECIMALS, InvalidAssetDecimals());
+    require(decimals <= MAX_ALLOWED_ASSET_DECIMALS, InvalidAssetDecimals());
 
     uint256 assetId = _assetCount++;
     IAssetInterestRateStrategy(irStrategy).setInterestRateData(assetId, data);
@@ -640,7 +644,7 @@ contract Hub is IHub, AccessManaged {
     require(spoke.active, SpokeNotActive());
     uint256 addCap = spoke.addCap;
     require(
-      addCap == Constants.MAX_CAP ||
+      addCap == MAX_CAP ||
         addCap * 10 ** asset.decimals >= previewAddByShares(assetId, spoke.addedShares) + amount,
       AddCapExceeded(addCap)
     );
@@ -672,7 +676,7 @@ contract Hub is IHub, AccessManaged {
     uint256 drawCap = spoke.drawCap;
     (uint256 drawn, uint256 premium) = _getSpokeOwed(spoke, assetId);
     require(
-      drawCap == Constants.MAX_CAP || drawCap * 10 ** asset.decimals >= drawn + premium + amount,
+      drawCap == MAX_CAP || drawCap * 10 ** asset.decimals >= drawn + premium + amount,
       DrawCapExceeded(drawCap)
     );
   }
@@ -726,7 +730,7 @@ contract Hub is IHub, AccessManaged {
     require(shares > 0, InvalidShares());
     uint256 addCap = receiver.addCap;
     require(
-      addCap == Constants.MAX_CAP ||
+      addCap == MAX_CAP ||
         addCap * 10 ** asset.decimals >=
         previewRemoveByShares(assetId, receiver.addedShares + shares),
       AddCapExceeded(addCap)

--- a/src/contracts/HubConfigurator.sol
+++ b/src/contracts/HubConfigurator.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.10;
 import {IERC20Metadata} from 'src/dependencies/openzeppelin/IERC20Metadata.sol';
 import {Ownable2Step, Ownable} from 'src/dependencies/openzeppelin/Ownable2Step.sol';
 import {SafeCast} from 'src/dependencies/openzeppelin/SafeCast.sol';
-import {Constants} from 'src/libraries/helpers/Constants.sol';
 import {IHub} from 'src/interfaces/IHub.sol';
 import {IHubConfigurator} from 'src/interfaces/IHubConfigurator.sol';
 
@@ -45,7 +44,11 @@ contract HubConfigurator is Ownable2Step, IHubConfigurator {
     targetHub.addSpoke(
       assetId,
       feeReceiver,
-      IHub.SpokeConfig({addCap: Constants.MAX_CAP, drawCap: Constants.MAX_CAP, active: true})
+      IHub.SpokeConfig({
+        addCap: IHub(targetHub).MAX_CAP(),
+        drawCap: IHub(targetHub).MAX_CAP(),
+        active: true
+      })
     );
 
     return assetId;
@@ -67,7 +70,11 @@ contract HubConfigurator is Ownable2Step, IHubConfigurator {
     targetHub.addSpoke(
       assetId,
       feeReceiver,
-      IHub.SpokeConfig({addCap: Constants.MAX_CAP, drawCap: Constants.MAX_CAP, active: true})
+      IHub.SpokeConfig({
+        addCap: IHub(targetHub).MAX_CAP(),
+        drawCap: IHub(targetHub).MAX_CAP(),
+        active: true
+      })
     );
 
     return assetId;
@@ -319,10 +326,10 @@ contract HubConfigurator is Ownable2Step, IHubConfigurator {
       hub.addSpoke(
         assetId,
         newFeeReceiver,
-        IHub.SpokeConfig({addCap: Constants.MAX_CAP, drawCap: Constants.MAX_CAP, active: true})
+        IHub.SpokeConfig({addCap: IHub(hub).MAX_CAP(), drawCap: IHub(hub).MAX_CAP(), active: true})
       );
     } else {
-      _updateSpokeCaps(hub, assetId, newFeeReceiver, Constants.MAX_CAP, Constants.MAX_CAP);
+      _updateSpokeCaps(hub, assetId, newFeeReceiver, IHub(hub).MAX_CAP(), IHub(hub).MAX_CAP());
     }
   }
 

--- a/src/contracts/Spoke.sol
+++ b/src/contracts/Spoke.sol
@@ -14,7 +14,6 @@ import {EIP712} from 'src/dependencies/solady/EIP712.sol';
 import {WadRayMath} from 'src/libraries/math/WadRayMath.sol';
 import {PercentageMath} from 'src/libraries/math/PercentageMath.sol';
 import {KeyValueListInMemory} from 'src/libraries/helpers/KeyValueListInMemory.sol';
-import {Constants} from 'src/libraries/helpers/Constants.sol';
 import {LiquidationLogic} from 'src/libraries/logic/LiquidationLogic.sol';
 import {PositionStatusMap} from 'src/libraries/configuration/PositionStatusMap.sol';
 import {MathUtils} from 'src/libraries/math/MathUtils.sol';
@@ -31,6 +30,24 @@ contract Spoke is ISpoke, Multicall, AccessManaged, EIP712 {
   using KeyValueListInMemory for KeyValueListInMemory.List;
   using PositionStatusMap for *;
   using MathUtils for *;
+
+  /// @inheritdoc ISpoke
+  uint8 public constant ORACLE_DECIMALS = 8;
+
+  /// @inheritdoc ISpoke
+  uint64 public constant HEALTH_FACTOR_LIQUIDATION_THRESHOLD =
+    LiquidationLogic.HEALTH_FACTOR_LIQUIDATION_THRESHOLD;
+
+  /// @inheritdoc ISpoke
+  uint256 public constant MIN_LEFTOVER_BASE = LiquidationLogic.MIN_LEFTOVER_BASE;
+
+  /// @inheritdoc ISpoke
+  uint24 public constant MAX_COLLATERAL_RISK = 1000_00; // 1000.00%
+
+  /// @inheritdoc ISpoke
+  bytes32 public constant SET_USER_POSITION_MANAGER_TYPEHASH =
+    0x758d23a3c07218b7ea0b4f7f63903c4e9d5cbde72d3bcfe3e9896639025a0214;
+  // keccak256('SetUserPositionManager(address positionManager,address user,bool approve,uint256 nonce,uint256 deadline)')
 
   IAaveOracle public oracle;
 
@@ -58,7 +75,7 @@ contract Spoke is ISpoke, Multicall, AccessManaged, EIP712 {
    */
   constructor(address authority_) AccessManaged(authority_) {
     require(authority_ != address(0), InvalidAddress());
-    _liquidationConfig.targetHealthFactor = Constants.HEALTH_FACTOR_LIQUIDATION_THRESHOLD;
+    _liquidationConfig.targetHealthFactor = HEALTH_FACTOR_LIQUIDATION_THRESHOLD;
     emit LiquidationConfigUpdate(_liquidationConfig);
   }
 
@@ -69,10 +86,7 @@ contract Spoke is ISpoke, Multicall, AccessManaged, EIP712 {
   /// @inheritdoc ISpoke
   function updateOracle(address newOracle) external restricted {
     oracle = IAaveOracle(newOracle);
-    require(
-      newOracle != address(0) && oracle.DECIMALS() == Constants.ORACLE_DECIMALS,
-      InvalidOracle()
-    );
+    require(newOracle != address(0) && oracle.DECIMALS() == ORACLE_DECIMALS, InvalidOracle());
     emit OracleUpdate(newOracle);
   }
 
@@ -83,9 +97,9 @@ contract Spoke is ISpoke, Multicall, AccessManaged, EIP712 {
 
   function updateLiquidationConfig(LiquidationConfig calldata config) external restricted {
     require(
-      config.targetHealthFactor >= Constants.HEALTH_FACTOR_LIQUIDATION_THRESHOLD &&
+      config.targetHealthFactor >= HEALTH_FACTOR_LIQUIDATION_THRESHOLD &&
         config.liquidationBonusFactor <= PercentageMath.PERCENTAGE_FACTOR &&
-        config.healthFactorForMaxBonus < Constants.HEALTH_FACTOR_LIQUIDATION_THRESHOLD,
+        config.healthFactorForMaxBonus < HEALTH_FACTOR_LIQUIDATION_THRESHOLD,
       InvalidLiquidationConfig()
     );
     _liquidationConfig = config;
@@ -427,7 +441,7 @@ contract Spoke is ISpoke, Multicall, AccessManaged, EIP712 {
     bytes32 hash = _hashTypedData(
       keccak256(
         abi.encode(
-          Constants.SET_USER_POSITION_MANAGER_TYPEHASH,
+          SET_USER_POSITION_MANAGER_TYPEHASH,
           positionManager,
           user,
           approve,
@@ -690,14 +704,14 @@ contract Spoke is ISpoke, Multicall, AccessManaged, EIP712 {
     // @dev refresh user position dynamic config only on borrow, withdraw, disableUsingAsCollateral
     UserAccountData memory userAccountData = _calculateAndRefreshUserAccountData(user);
     require(
-      userAccountData.healthFactor >= Constants.HEALTH_FACTOR_LIQUIDATION_THRESHOLD,
+      userAccountData.healthFactor >= HEALTH_FACTOR_LIQUIDATION_THRESHOLD,
       HealthFactorBelowThreshold()
     );
     return userAccountData.userRiskPremium;
   }
 
   function _validateReserveConfig(ReserveConfig calldata config) internal pure {
-    require(config.collateralRisk <= Constants.MAX_COLLATERAL_RISK, InvalidCollateralRisk());
+    require(config.collateralRisk <= MAX_COLLATERAL_RISK, InvalidCollateralRisk());
   }
 
   function _validateDynamicReserveConfig(DynamicReserveConfig calldata config) internal pure {

--- a/src/interfaces/IHub.sol
+++ b/src/interfaces/IHub.sol
@@ -431,4 +431,8 @@ interface IHub is IHubBase, IAccessManaged {
   function getSpokeTotalOwed(uint256 assetId, address spoke) external view returns (uint256);
 
   function getAssetCount() external view returns (uint256);
+
+  function MAX_ALLOWED_ASSET_DECIMALS() external view returns (uint8);
+
+  function MAX_CAP() external view returns (uint56);
 }

--- a/src/interfaces/ISpoke.sol
+++ b/src/interfaces/ISpoke.sol
@@ -392,4 +392,18 @@ interface ISpoke is ISpokeBase, IMulticall, IAccessManaged {
   function nonces(address user) external view returns (uint256);
 
   function DOMAIN_SEPARATOR() external view returns (bytes32);
+
+  function ORACLE_DECIMALS() external view returns (uint8);
+
+  function HEALTH_FACTOR_LIQUIDATION_THRESHOLD() external view returns (uint64);
+
+  /**
+   * @dev This constant represents the minimum amount of assets in base currency that need to be leftover after a liquidation, if not clearing collateral on a position completely.
+   * @notice The default value assumes that the basePrice is usd denominated by 26 decimals.
+   */
+  function MIN_LEFTOVER_BASE() external view returns (uint256);
+
+  function MAX_COLLATERAL_RISK() external view returns (uint24);
+
+  function SET_USER_POSITION_MANAGER_TYPEHASH() external view returns (bytes32);
 }

--- a/src/libraries/logic/LiquidationLogic.sol
+++ b/src/libraries/logic/LiquidationLogic.sol
@@ -6,7 +6,6 @@ import {SafeCast} from 'src/dependencies/openzeppelin/SafeCast.sol';
 import {IHub, IHubBase} from 'src/interfaces/IHub.sol';
 import {ISpoke, ISpokeBase} from 'src/interfaces/ISpoke.sol';
 import {IAaveOracle} from 'src/interfaces/IAaveOracle.sol';
-import {Constants} from 'src/libraries/helpers/Constants.sol';
 import {PositionStatusMap} from 'src/libraries/configuration/PositionStatusMap.sol';
 import {PercentageMath} from 'src/libraries/math/PercentageMath.sol';
 import {WadRayMath} from 'src/libraries/math/WadRayMath.sol';
@@ -103,10 +102,10 @@ library LiquidationLogic {
     uint256 borrowedAssetsCount;
   }
 
-  /**
-   * @dev This constant represents the minimum amount of assets in base currency that need to be leftover after a liquidation, if not clearing collateral on a position completely.
-   * @notice The default value assumes that the basePrice is usd denominated by 26 decimals.
-   */
+  /// @dev see ISpoke
+  uint64 public constant HEALTH_FACTOR_LIQUIDATION_THRESHOLD = 1e18;
+
+  /// @dev see ISpoke
   uint256 constant MIN_LEFTOVER_BASE = 1000e26;
 
   function calculateLiquidationBonus(
@@ -123,12 +122,12 @@ library LiquidationLogic {
       .percentMulDown(liquidationBonusFactor) + PercentageMath.PERCENTAGE_FACTOR;
 
     // linear interpolation between min and max
-    // denominator cannot be zero as healthFactorForMaxBonus is always < Constants.HEALTH_FACTOR_LIQUIDATION_THRESHOLD
+    // denominator cannot be zero as healthFactorForMaxBonus is always < HEALTH_FACTOR_LIQUIDATION_THRESHOLD
     return
       minLiquidationBonus +
       (maxLiquidationBonus - minLiquidationBonus).mulDivDown(
-        Constants.HEALTH_FACTOR_LIQUIDATION_THRESHOLD - healthFactor,
-        Constants.HEALTH_FACTOR_LIQUIDATION_THRESHOLD - healthFactorForMaxBonus
+        HEALTH_FACTOR_LIQUIDATION_THRESHOLD - healthFactor,
+        HEALTH_FACTOR_LIQUIDATION_THRESHOLD - healthFactorForMaxBonus
       );
   }
 
@@ -141,7 +140,7 @@ library LiquidationLogic {
     );
     require(!params.collateralReservePaused && !params.debtReservePaused, ISpoke.ReservePaused());
     require(
-      params.healthFactor < Constants.HEALTH_FACTOR_LIQUIDATION_THRESHOLD,
+      params.healthFactor < HEALTH_FACTOR_LIQUIDATION_THRESHOLD,
       ISpoke.HealthFactorNotBelowThreshold()
     );
     require(
@@ -159,7 +158,7 @@ library LiquidationLogic {
     );
 
     // denominator cannot be zero as liquidationBonus * collateralFactor is always < PercentageMath.PERCENTAGE_FACTOR
-    // and targetHealthFactor is always >= Constants.HEALTH_FACTOR_LIQUIDATION_THRESHOLD
+    // and targetHealthFactor is always >= HEALTH_FACTOR_LIQUIDATION_THRESHOLD
     return
       params.totalDebtInBaseCurrency.mulDivUp(
         params.debtAssetUnit * (params.targetHealthFactor - params.healthFactor),

--- a/tests/Base.t.sol
+++ b/tests/Base.t.sol
@@ -23,12 +23,12 @@ import {PercentageMath} from 'src/libraries/math/PercentageMath.sol';
 import {WadRayMath} from 'src/libraries/math/WadRayMath.sol';
 import {SharesMath} from 'src/libraries/math/SharesMath.sol';
 import {MathUtils} from 'src/libraries/math/MathUtils.sol';
-import {Constants} from 'src/libraries/helpers/Constants.sol';
 import {PositionStatusMap} from 'src/libraries/configuration/PositionStatusMap.sol';
 import {AssetInterestRateStrategy, IAssetInterestRateStrategy, IBasicInterestRateStrategy} from 'src/contracts/AssetInterestRateStrategy.sol';
 import {LiquidationLogic} from 'src/libraries/logic/LiquidationLogic.sol';
 import {Roles} from 'src/libraries/types/Roles.sol';
 import {Utils} from 'tests/Utils.sol';
+import {Constants} from 'tests/Constants.sol';
 import {EIP712Types} from 'src/libraries/types/EIP712Types.sol';
 
 // mocks

--- a/tests/Constants.sol
+++ b/tests/Constants.sol
@@ -3,14 +3,14 @@
 pragma solidity ^0.8.0;
 
 library Constants {
-  /// @dev Hub Constants
+  // Hub
   uint8 public constant MAX_ALLOWED_ASSET_DECIMALS = 18;
   uint56 public constant MAX_CAP = type(uint56).max;
-  /// @dev Spoke Constants
+
+  // Spoke
   uint8 public constant ORACLE_DECIMALS = 8;
   uint64 public constant HEALTH_FACTOR_LIQUIDATION_THRESHOLD = 1e18;
   uint24 public constant MAX_COLLATERAL_RISK = 1000_00; // 1000.00%
-  // keccak256('SetUserPositionManager(address positionManager,address user,bool approve,uint256 nonce,uint256 deadline)')
   bytes32 public constant SET_USER_POSITION_MANAGER_TYPEHASH =
     0x758d23a3c07218b7ea0b4f7f63903c4e9d5cbde72d3bcfe3e9896639025a0214;
 }


### PR DESCRIPTION
Based on #720 
Blocked by #707 -> will need conflicts resolving

Closes #568 

### Notes

#### Only using Constants lib file on tests.
Otherwise we need to do smt like `IHub(hubInstance).CONSTANT()` every time and makes tests code messier.

#### Spoke constants are referring LiquidationLogic constants
Took the decision to move all libs' constants to main contract (`Spoke`) and refer them from there. Main reason is that one of the constants is used in both sides (Spoke and LiquidationLogic lib). Open to suggestions.