### PR TITLE
fix: remove unused error & event

### DIFF
--- a/src/spoke/interfaces/ISpoke.sol
+++ b/src/spoke/interfaces/ISpoke.sol
@@ -159,7 +159,6 @@ interface ISpoke is ISpokeBase, IMulticall, IAccessManaged {
     address indexed user,
     IHubBase.PremiumDelta premiumDelta
   );
-  event UpdateOracle(address indexed oracle);
   event UpdateReservePriceSource(uint256 indexed reserveId, address indexed priceSource);
   event UpdateLiquidationConfig(LiquidationConfig config);
 


### PR DESCRIPTION
- minor fix to rm unused spoke error `InvalidOracle`, `UpdateOracle` event now that oracle is immutable

closes #765 