### PR TITLE
fix: CollateralFactor strictly less than 100_00

### DIFF
--- a/src/spoke/Spoke.sol
+++ b/src/spoke/Spoke.sol
@@ -691,7 +691,7 @@ abstract contract Spoke is ISpoke, Multicall, AccessManagedUpgradeable, EIP712 {
   function _validateDynamicReserveConfig(DynamicReserveConfig calldata config) internal pure {
     // Enforce that at moment loan is taken, there should be enough collateral to cover liquidation
     require(
-      config.collateralFactor <= PercentageMath.PERCENTAGE_FACTOR &&
+      config.collateralFactor < PercentageMath.PERCENTAGE_FACTOR &&
         config.maxLiquidationBonus >= PercentageMath.PERCENTAGE_FACTOR &&
         config.maxLiquidationBonus.percentMulUp(config.collateralFactor) <
         PercentageMath.PERCENTAGE_FACTOR,

--- a/tests/unit/Spoke/Spoke.DynamicConfig.t.sol
+++ b/tests/unit/Spoke/Spoke.DynamicConfig.t.sol
@@ -58,12 +58,18 @@ contract SpokeDynamicConfigTest is SpokeBase {
     public
   {
     uint16 collateralFactor = vm
-      .randomUint(PercentageMath.PERCENTAGE_FACTOR + 1, type(uint16).max)
+      .randomUint(PercentageMath.PERCENTAGE_FACTOR, type(uint16).max)
       .toUint16();
 
     uint256 reserveId = _randomReserveId(spoke1);
     ISpoke.DynamicReserveConfig memory config = spoke1.getDynamicReserveConfig(reserveId);
     config.collateralFactor = collateralFactor;
+
+    vm.expectRevert(ISpoke.InvalidCollateralFactorAndMaxLiquidationBonus.selector, address(spoke1));
+    vm.prank(SPOKE_ADMIN);
+    spoke1.addDynamicReserveConfig(reserveId, config);
+
+    config.collateralFactor = PercentageMath.PERCENTAGE_FACTOR.toUint16();
 
     vm.expectRevert(ISpoke.InvalidCollateralFactorAndMaxLiquidationBonus.selector, address(spoke1));
     vm.prank(SPOKE_ADMIN);


### PR DESCRIPTION
- Stermi's initial suggestion here was to enforce that LB > 100_00 (ie 0) strictly. We want to leave this condition as is to give us more flexibility in case LB ever needs to remain 0, and instead ensure proper config.
- However, due to the liquidations conditions of ensuring collateral can cover a liquidation, plus ensuring the debtToTarget calc in liquidations never has a 0 denominator, we already enforce:
```
config.liquidationBonus.percentMulUp(config.collateralFactor) <
       PercentageMath.PERCENTAGE_FACTOR
```

with LB >=100_00, this means that CF must be < 100_00 strictly anyway. Therefore we implemented this CF < 100_00 enforcement to be consistent on the condition.

- partially closes #655 