### PR TITLE
test: POC liquidation with zero debt shares via donation

### DIFF
--- a/tests/unit/Spoke/Liquidations/Spoke.Liq.t.sol
+++ b/tests/unit/Spoke/Liquidations/Spoke.Liq.t.sol
@@ -47,8 +47,8 @@ contract SpokeLiqTest is SpokeBase {
   function test_liq_donation() public {
     uint256 desiredHF = 0.95e18;
 
-    updateCollateralFactor(spoke1, _daiReserveId(spoke1), 50_00);
-    _updateMaxLiquidationBonus(spoke1, _daiReserveId(spoke1), 199_00); // >0 LB so that liquidator earns
+    updateCollateralFactor(spoke1, _daiReserveId(spoke1), 10_00);
+    _updateMaxLiquidationBonus(spoke1, _daiReserveId(spoke1), 999_00); // >0 LB so that liquidator earns
     _updateLiquidationFee(spoke1, _daiReserveId(spoke1), 0);
     _updateLiquidationConfig(
       spoke1,
@@ -68,7 +68,7 @@ contract SpokeLiqTest is SpokeBase {
     skip(365 days);
     // now debt index is 11
 
-    Utils.supplyCollateral(spoke1, _daiReserveId(spoke1), bob, 5000e18, bob);
+    Utils.supplyCollateral(spoke1, _daiReserveId(spoke1), bob, 1_000_000e18, bob);
     _borrowToBeAtHf(spoke1, bob, _daiReserveId(spoke1), desiredHF);
     uint256 liquidatorBalanceBefore = tokenList.dai.balanceOf(liquidator);
 


### PR DESCRIPTION
see test `test_liq_donation`
scenario:
- bob has a liquidatable position of HF=0.95
- debt index has been inflated to 10
- liquidator attacker liquidates some debt amt < 1 full share multiple times. The repay donation causes < 1 debt share being reduced, with > 1 coll share reduced each time
- by the end of the chained liqs, attacker has earned DAI (spending only gas) from LiqBonus, to put bob's user position in a more vulnerable position, by reducing collateral shares without affecting debt shares, reducing HF and putting user at higher risk of bad debt.
- however, this can only be done while position > $1k, ie dust threshold 

(took 100k liqCalls:)
<img width="817" height="152" alt="Screenshot 2025-09-17 at 17 51 35" src="https://github.com/user-attachments/assets/02012305-6dd2-4a67-9a97-fdd9c9300a7b" />