### PR TITLE
fix: `rescueToken` consistency

### DIFF
--- a/src/interfaces/IRescuable.sol
+++ b/src/interfaces/IRescuable.sol
@@ -9,8 +9,9 @@ interface IRescuable {
    * @notice Recovers ERC20 tokens sent to this contract.
    * @param token Address of the ERC20 token to rescue.
    * @param to Address to send the rescued tokens to.
+   * @param amount Amount of tokens to rescue.
    **/
-  function rescueToken(address token, address to) external;
+  function rescueToken(address token, address to, uint256 amount) external;
 
   /**
    * @notice Recovers native asset left in this contract.

--- a/src/utils/Rescuable.sol
+++ b/src/utils/Rescuable.sol
@@ -16,8 +16,8 @@ abstract contract Rescuable is IRescuable {
   }
 
   /// @inheritdoc IRescuable
-  function rescueToken(address token, address to) external onlyRescueGuardian {
-    IERC20(token).safeTransfer(to, IERC20(token).balanceOf(address(this)));
+  function rescueToken(address token, address to, uint256 amount) external onlyRescueGuardian {
+    IERC20(token).safeTransfer(to, amount);
   }
 
   /// @inheritdoc IRescuable

--- a/tests/unit/Rescuable.t.sol
+++ b/tests/unit/Rescuable.t.sol
@@ -26,7 +26,7 @@ contract RescuableTest is Base {
     uint256 prevBalanceThis = tokenList.dai.balanceOf(address(this));
 
     vm.prank(address(ADMIN));
-    rescuable.rescueToken(address(tokenList.dai), address(this));
+    rescuable.rescueToken(address(tokenList.dai), address(this), lostAmount);
 
     assertEq(tokenList.dai.balanceOf(address(this)), prevBalanceThis + lostAmount);
     assertEq(tokenList.dai.balanceOf(address(rescuable)), 0);
@@ -39,7 +39,7 @@ contract RescuableTest is Base {
 
     vm.expectRevert(IRescuable.OnlyRescueGuardian.selector);
     vm.prank(bob);
-    rescuable.rescueToken(address(tokenList.dai), address(this));
+    rescuable.rescueToken(address(tokenList.dai), address(this), lostAmount);
   }
 
   function test_rescueNative_fuzz(uint256 lostAmount) public {


### PR DESCRIPTION
- ensure consistency between `rescueToken` and `rescueNative`, so that arbitrary amount input is accepted

closes #797 