### PR TITLE
fix: `TransferShares` indexed params

### DIFF
--- a/snapshots/Hub.Operations.json
+++ b/snapshots/Hub.Operations.json
@@ -3,12 +3,12 @@
   "draw": "111323",
   "eliminateDeficit: full": "62859",
   "eliminateDeficit: partial": "67635",
-  "payFee": "81750",
-  "refreshPremium": "83887",
+  "payFee": "81982",
+  "refreshPremium": "83888",
   "remove: full": "78590",
   "remove: partial": "85090",
-  "reportDeficit": "110588",
-  "restore: full": "112646",
-  "restore: partial": "118498",
-  "transferShares": "87437"
+  "reportDeficit": "110589",
+  "restore: full": "112647",
+  "restore: partial": "118499",
+  "transferShares": "87658"
 }

--- a/snapshots/Spoke.Operations.json
+++ b/snapshots/Spoke.Operations.json
@@ -1,13 +1,13 @@
 {
-  "borrow: first": "251723",
-  "borrow: second action, same reserve": "215195",
+  "borrow: first": "251724",
+  "borrow: second action, same reserve": "215196",
   "liquidationCall: full": "319869",
-  "liquidationCall: partial": "343130",
-  "permitReserve + repay (multicall)": "275540",
+  "liquidationCall: partial": "343131",
+  "permitReserve + repay (multicall)": "275541",
   "permitReserve + supply (multicall)": "145234",
   "permitReserve + supply + enable collateral (multicall)": "179214",
-  "repay: full": "176349",
-  "repay: partial": "233335",
+  "repay: full": "176350",
+  "repay: partial": "233336",
   "setUserPositionManagerWithSig: disable": "44146",
   "setUserPositionManagerWithSig: enable": "68169",
   "supply + enable collateral (multicall)": "157156",
@@ -24,5 +24,5 @@
   "usingAsCollateral: 1 borrow, enable": "29731",
   "withdraw: 0 borrows, full": "135491",
   "withdraw: 0 borrows, partial": "137594",
-  "withdraw: 1 borrow, partial": "240386"
+  "withdraw: 1 borrow, partial": "240387"
 }

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -348,7 +348,7 @@ contract Hub is IHub, AccessManaged {
     _transferShares(sender, receiver, shares);
     asset.updateDrawnRate(assetId);
 
-    emit TransferShares(assetId, shares, msg.sender, feeReceiver);
+    emit TransferShares(assetId, msg.sender, feeReceiver, shares);
   }
 
   /// @inheritdoc IHub
@@ -362,7 +362,7 @@ contract Hub is IHub, AccessManaged {
     _transferShares(sender, receiver, shares);
     asset.updateDrawnRate(assetId);
 
-    emit TransferShares(assetId, shares, msg.sender, toSpoke);
+    emit TransferShares(assetId, msg.sender, toSpoke, shares);
   }
 
   /// @inheritdoc IHub

--- a/src/hub/interfaces/IHubBase.sol
+++ b/src/hub/interfaces/IHubBase.sol
@@ -75,11 +75,16 @@ interface IHubBase {
   /**
    * @notice Emitted on the transfer shares action.
    * @param assetId The identifier of the asset.
-   * @param shares The amount of shares transferred.
    * @param sender The address of the sender.
    * @param receiver The address of the receiver.
+   * @param shares The amount of shares transferred.
    */
-  event TransferShares(uint256 indexed assetId, uint256 shares, address sender, address receiver);
+  event TransferShares(
+    uint256 indexed assetId,
+    address indexed sender,
+    address indexed receiver,
+    uint256 shares
+  );
 
   /**
    * @notice Add asset on behalf of user.

--- a/tests/unit/Hub/Hub.PayFee.t.sol
+++ b/tests/unit/Hub/Hub.PayFee.t.sol
@@ -104,9 +104,9 @@ contract HubPayFeeTest is HubBase {
     vm.expectEmit(address(hub1));
     emit IHubBase.TransferShares(
       daiAssetId,
-      feeShares,
       address(spoke1),
-      _getFeeReceiver(hub1, daiAssetId)
+      _getFeeReceiver(hub1, daiAssetId),
+      feeShares
     );
 
     vm.prank(address(spoke1));

--- a/tests/unit/Hub/Hub.TransferShares.t.sol
+++ b/tests/unit/Hub/Hub.TransferShares.t.sol
@@ -66,6 +66,9 @@ contract HubTransferSharesTest is HubBase {
     assertEq(suppliedShares, hub1.convertToAddedAssets(daiAssetId, supplyAmount));
     assertEq(suppliedShares, assetSuppliedShares);
 
+    vm.expectEmit(address(hub1));
+    emit IHubBase.TransferShares(daiAssetId, address(spoke1), address(spoke2), moveAmount);
+
     // transfer supplied shares from spoke1 to spoke2
     vm.prank(address(spoke1));
     hub1.transferShares(daiAssetId, moveAmount, address(spoke2));


### PR DESCRIPTION
Declare sender and receiver as indexed params in `TransferShares` event

closes #805 