### PR TITLE
fix: rename `addLiquidationBonus`

### DIFF
--- a/src/spoke/SpokeConfigurator.sol
+++ b/src/spoke/SpokeConfigurator.sol
@@ -151,16 +151,16 @@ contract SpokeConfigurator is Ownable2Step, ISpokeConfigurator {
   }
 
   /// @inheritdoc ISpokeConfigurator
-  function addLiquidationBonus(
+  function addMaxLiquidationBonus(
     address spoke,
     uint256 reserveId,
-    uint256 liquidationBonus
+    uint256 maxLiquidationBonus
   ) external onlyOwner {
     ISpoke targetSpoke = ISpoke(spoke);
     ISpoke.DynamicReserveConfig memory dynamicReserveConfig = targetSpoke.getDynamicReserveConfig(
       reserveId
     );
-    dynamicReserveConfig.maxLiquidationBonus = liquidationBonus.toUint32();
+    dynamicReserveConfig.maxLiquidationBonus = maxLiquidationBonus.toUint32();
     targetSpoke.addDynamicReserveConfig(reserveId, dynamicReserveConfig);
   }
 

--- a/src/spoke/interfaces/ISpokeConfigurator.sol
+++ b/src/spoke/interfaces/ISpokeConfigurator.sol
@@ -125,12 +125,16 @@ interface ISpokeConfigurator {
   ) external;
 
   /**
-   * @notice Adds a dynamic config to a reserve, identical to the latest one but with the specified liquidation bonus.
+   * @notice Adds a dynamic config to a reserve, identical to the latest one but with the specified max liquidation bonus.
    * @param spoke The address of the spoke.
    * @param reserveId The identifier of the reserve.
-   * @param liquidationBonus The new liquidation bonus.
+   * @param maxLiquidationBonus The new max liquidation bonus.
    */
-  function addLiquidationBonus(address spoke, uint256 reserveId, uint256 liquidationBonus) external;
+  function addMaxLiquidationBonus(
+    address spoke,
+    uint256 reserveId,
+    uint256 maxLiquidationBonus
+  ) external;
 
   /**
    * @notice Updates an existing liquidation bonus of a reserve at the specified key.

--- a/tests/unit/SpokeConfigurator.t.sol
+++ b/tests/unit/SpokeConfigurator.t.sol
@@ -385,10 +385,10 @@ contract SpokeConfiguratorTest is SpokeBase {
   function test_addLiquidationBonus_revertsWith_OwnableUnauthorizedAccount() public {
     vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, alice));
     vm.prank(alice);
-    spokeConfigurator.addLiquidationBonus(spokeAddr, reserveId, 0);
+    spokeConfigurator.addMaxLiquidationBonus(spokeAddr, reserveId, 0);
   }
 
-  function test_addLiquidationBonus() public {
+  function test_addMaxLiquidationBonus() public {
     uint32 newLiquidationBonus = PercentageMath.PERCENTAGE_FACTOR.toUint32() + 1;
 
     ISpoke.DynamicReserveConfig memory expectedDynamicReserveConfig = spoke.getDynamicReserveConfig(
@@ -405,7 +405,7 @@ contract SpokeConfiguratorTest is SpokeBase {
     vm.expectEmit(address(spoke));
     emit ISpoke.AddDynamicReserveConfig(reserveId, expectedConfigKey, expectedDynamicReserveConfig);
     vm.prank(SPOKE_CONFIGURATOR_ADMIN);
-    spokeConfigurator.addLiquidationBonus(spokeAddr, reserveId, newLiquidationBonus);
+    spokeConfigurator.addMaxLiquidationBonus(spokeAddr, reserveId, newLiquidationBonus);
 
     assertEq(spoke.getDynamicReserveConfig(reserveId), expectedDynamicReserveConfig);
   }


### PR DESCRIPTION
- `addLiquidationBonus` function refactored to follow the new nomenclature adopted by the Spoke: `liquidationBonus` -> `maxLiquidationBonus`

closes #807 