### PR TITLE
fix: use ownable2step on treasury spoke

### DIFF
--- a/src/spoke/TreasurySpoke.sol
+++ b/src/spoke/TreasurySpoke.sol
@@ -2,7 +2,7 @@
 // Copyright (c) 2025 Aave Labs
 pragma solidity ^0.8.0;
 
-import {Ownable} from 'src/dependencies/openzeppelin/Ownable.sol';
+import {Ownable2Step, Ownable} from 'src/dependencies/openzeppelin/Ownable2Step.sol';
 import {SafeERC20} from 'src/dependencies/openzeppelin/SafeERC20.sol';
 import {IERC20} from 'src/dependencies/openzeppelin/IERC20.sol';
 import {MathUtils} from 'src/libraries/math/MathUtils.sol';
@@ -16,7 +16,7 @@ import {ITreasurySpoke, ISpokeBase} from 'src/spoke/interfaces/ITreasurySpoke.so
  * @dev Utilizes all assets from the Hub without restrictions, making reserve and asset identifiers aligned.
  * @dev Allows withdraw to claim fees and supply to invest back into the Hub via this dedicated spoke.
  */
-contract TreasurySpoke is ITreasurySpoke, Ownable {
+contract TreasurySpoke is ITreasurySpoke, Ownable2Step {
   using SafeERC20 for IERC20;
 
   /// @inheritdoc ITreasurySpoke

--- a/tests/unit/Spoke/TreasurySpoke.t.sol
+++ b/tests/unit/Spoke/TreasurySpoke.t.sol
@@ -12,9 +12,12 @@ contract TreasurySpokeTest is SpokeBase {
     _testToken = new MockERC20();
   }
 
-  function test_deploy_revertsWith_InvalidAddress_hub() public {
-    vm.expectRevert(abi.encodeWithSelector(ISpoke.InvalidAddress.selector));
+  function test_deploy_reverts_on_invalid_params() public {
+    vm.expectRevert(ISpoke.InvalidAddress.selector);
     new TreasurySpoke(vm.randomAddress(), address(0));
+
+    vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableInvalidOwner.selector, address(0)));
+    new TreasurySpoke(address(0), vm.randomAddress());
   }
 
   function test_initial_state() public view {
@@ -23,6 +26,8 @@ contract TreasurySpokeTest is SpokeBase {
       assertEq(treasurySpoke.getSuppliedAmount(i), 0);
       assertEq(treasurySpoke.getSuppliedShares(i), 0);
     }
+    assertEq(Ownable2Step(address(treasurySpoke)).owner(), TREASURY_ADMIN);
+    assertEq(Ownable2Step(address(treasurySpoke)).pendingOwner(), address(0));
   }
 
   function test_supply_revertsWith_Unauthorized(address caller) public {


### PR DESCRIPTION
- use ownable2step instead of ownable for TreasurySpoke 