### PR TITLE
fix: Reorder functions

### DIFF
--- a/src/hub/interfaces/IAssetInterestRateStrategy.sol
+++ b/src/hub/interfaces/IAssetInterestRateStrategy.sol
@@ -51,22 +51,6 @@ interface IAssetInterestRateStrategy is IBasicInterestRateStrategy {
   /// @notice Thrown when the optimal usage ratio is less than `MIN_OPTIMAL_POINT` or greater than `MAX_OPTIMAL_POINT`.
   error InvalidOptimalUsageRatio();
 
-  /// @notice Returns the maximum value achievable for the borrow rate.
-  /// @return The maximum rate, in bps.
-  function MAX_BORROW_RATE() external view returns (uint256);
-
-  /// @notice Returns the minimum optimal usage ratio.
-  /// @return The minimum optimal usage ratio, in bps.
-  function MIN_OPTIMAL_RATIO() external view returns (uint256);
-
-  /// @notice Returns the maximum optimal usage ratio.
-  /// @return The maximum optimal usage ratio, in bps.
-  function MAX_OPTIMAL_RATIO() external view returns (uint256);
-
-  /// @notice Returns the associated address of the hub.
-  /// @return The address of the hub.
-  function HUB() external view returns (address);
-
   /// @notice Returns the full InterestRateData struct for the given asset.
   /// @param assetId The identifier of the asset to get the data for.
   /// @return The InterestRateData struct for the given asset, all in bps.
@@ -98,4 +82,20 @@ interface IAssetInterestRateStrategy is IBasicInterestRateStrategy {
   /// @param assetId The identifier of the asset to get the maximum variable borrow rate for.
   /// @return The maximum variable borrow rate, in bps.
   function getMaxVariableBorrowRate(uint256 assetId) external view returns (uint256);
+
+  /// @notice Returns the maximum value achievable for the borrow rate.
+  /// @return The maximum rate, in bps.
+  function MAX_BORROW_RATE() external view returns (uint256);
+
+  /// @notice Returns the minimum optimal usage ratio.
+  /// @return The minimum optimal usage ratio, in bps.
+  function MIN_OPTIMAL_RATIO() external view returns (uint256);
+
+  /// @notice Returns the maximum optimal usage ratio.
+  /// @return The maximum optimal usage ratio, in bps.
+  function MAX_OPTIMAL_RATIO() external view returns (uint256);
+
+  /// @notice Returns the associated address of the hub.
+  /// @return The address of the hub.
+  function HUB() external view returns (address);
 }

--- a/src/hub/interfaces/IHubBase.sol
+++ b/src/hub/interfaces/IHubBase.sol
@@ -61,18 +61,6 @@ interface IHubBase {
   /// @param premiumDelta The premium delta data struct.
   event RefreshPremium(uint256 indexed assetId, address indexed spoke, PremiumDelta premiumDelta);
 
-  /// @notice Emitted on the `transferShares` action.
-  /// @param assetId The identifier of the asset.
-  /// @param sender The address of the sender.
-  /// @param receiver The address of the receiver.
-  /// @param shares The amount of shares transferred.
-  event TransferShares(
-    uint256 indexed assetId,
-    address indexed sender,
-    address indexed receiver,
-    uint256 shares
-  );
-
   /// @notice Emitted on the `reportDeficit` action.
   /// @param assetId The identifier of the asset.
   /// @param spoke The address of the spoke.
@@ -87,6 +75,18 @@ interface IHubBase {
     PremiumDelta premiumDelta,
     uint256 drawnAmount,
     uint256 premiumAmount
+  );
+
+  /// @notice Emitted on the `transferShares` action.
+  /// @param assetId The identifier of the asset.
+  /// @param sender The address of the sender.
+  /// @param receiver The address of the receiver.
+  /// @param shares The amount of shares transferred.
+  event TransferShares(
+    uint256 indexed assetId,
+    address indexed sender,
+    address indexed receiver,
+    uint256 shares
   );
 
   /// @notice Add asset on behalf of user.
@@ -157,12 +157,6 @@ interface IHubBase {
   /// @param shares The amount of shares to pay to feeReceiver.
   function payFeeShares(uint256 assetId, uint256 shares) external;
 
-  /// @notice Returns the underlying address and decimals of the specified asset.
-  /// @param assetId The identifier of the asset.
-  /// @return The underlying address of the asset.
-  /// @return The decimals of the asset.
-  function getAssetUnderlyingAndDecimals(uint256 assetId) external view returns (address, uint8);
-
   /// @notice Converts the specified amount of assets to shares upon an `add` action.
   /// @dev Rounds down to the nearest shares amount.
   /// @param assetId The identifier of the asset.
@@ -219,6 +213,22 @@ interface IHubBase {
   /// @return The amount of assets converted from shares amount.
   function previewRestoreByShares(uint256 assetId, uint256 shares) external view returns (uint256);
 
+  /// @notice Returns the underlying address and decimals of the specified asset.
+  /// @param assetId The identifier of the asset.
+  /// @return The underlying address of the asset.
+  /// @return The decimals of the asset.
+  function getAssetUnderlyingAndDecimals(uint256 assetId) external view returns (address, uint8);
+
+  /// @notice Returns the total amount of the specified asset added to the hub.
+  /// @param assetId The identifier of the asset.
+  /// @return The amount of the asset added.
+  function getAddedAssets(uint256 assetId) external view returns (uint256);
+
+  /// @notice Returns the total amount of shares of the specified asset added to the hub.
+  /// @param assetId The identifier of the asset.
+  /// @return The amount of shares of the asset added.
+  function getAddedShares(uint256 assetId) external view returns (uint256);
+
   /// @notice Returns the amount of owed drawn and premium assets for the specified asset.
   /// @param assetId The identifier of the asset.
   /// @return The amount of owed drawn assets.
@@ -241,6 +251,20 @@ interface IHubBase {
   /// @return The premium offset of the asset.
   /// @return The realized premium of the asset.
   function getAssetPremiumData(uint256 assetId) external view returns (uint256, uint256, uint256);
+
+  /// @notice Returns the total amount of the specified assets added to the hub by the specified spoke.
+  /// @dev If spoke is `asset.feeReceiver`, includes converted `unrealizedFeeShares` in return value.
+  /// @param assetId The identifier of the asset.
+  /// @param spoke The address of the spoke.
+  /// @return The amount of added assets.
+  function getSpokeAddedAssets(uint256 assetId, address spoke) external view returns (uint256);
+
+  /// @notice Returns the total amount of shares of the specified asset added to the hub by the specified spoke.
+  /// @dev If spoke is `asset.feeReceiver`, includes `unrealizedFeeShares` in return value.
+  /// @param assetId The identifier of the asset.
+  /// @param spoke The address of the spoke.
+  /// @return The amount of added shares.
+  function getSpokeAddedShares(uint256 assetId, address spoke) external view returns (uint256);
 
   /// @notice Returns the amount of the specified assets owed to the hub by the specified spoke.
   /// @param assetId The identifier of the asset.
@@ -271,28 +295,4 @@ interface IHubBase {
     uint256 assetId,
     address spoke
   ) external view returns (uint256, uint256, uint256);
-
-  /// @notice Returns the total amount of the specified asset added to the hub.
-  /// @param assetId The identifier of the asset.
-  /// @return The amount of the asset added.
-  function getAddedAssets(uint256 assetId) external view returns (uint256);
-
-  /// @notice Returns the total amount of shares of the specified asset added to the hub.
-  /// @param assetId The identifier of the asset.
-  /// @return The amount of shares of the asset added.
-  function getAddedShares(uint256 assetId) external view returns (uint256);
-
-  /// @notice Returns the total amount of the specified assets added to the hub by the specified spoke.
-  /// @dev If spoke is `asset.feeReceiver`, includes converted `unrealizedFeeShares` in return value.
-  /// @param assetId The identifier of the asset.
-  /// @param spoke The address of the spoke.
-  /// @return The amount of added assets.
-  function getSpokeAddedAssets(uint256 assetId, address spoke) external view returns (uint256);
-
-  /// @notice Returns the total amount of shares of the specified asset added to the hub by the specified spoke.
-  /// @dev If spoke is `asset.feeReceiver`, includes `unrealizedFeeShares` in return value.
-  /// @param assetId The identifier of the asset.
-  /// @param spoke The address of the spoke.
-  /// @return The amount of added shares.
-  function getSpokeAddedShares(uint256 assetId, address spoke) external view returns (uint256);
 }

--- a/src/position-manager/NativeTokenGateway.sol
+++ b/src/position-manager/NativeTokenGateway.sol
@@ -52,11 +52,6 @@ contract NativeTokenGateway is
   }
 
   /// @inheritdoc INativeTokenGateway
-  function renouncePositionManagerRole(address user) external onlyOwner {
-    _spoke.renouncePositionManagerRole(user);
-  }
-
-  /// @inheritdoc INativeTokenGateway
   function supplyNative(uint256 reserveId, uint256 amount) external payable nonReentrant {
     (IERC20 underlying, address hub) = _getReserveData(reserveId);
     _validateParams(underlying, amount);
@@ -115,6 +110,11 @@ contract NativeTokenGateway is
     if (leftovers > 0) {
       Address.sendValue(payable(msg.sender), leftovers);
     }
+  }
+
+  /// @inheritdoc INativeTokenGateway
+  function renouncePositionManagerRole(address user) external onlyOwner {
+    _spoke.renouncePositionManagerRole(user);
   }
 
   /// @inheritdoc INativeTokenGateway

--- a/src/spoke/interfaces/IAaveOracle.sol
+++ b/src/spoke/interfaces/IAaveOracle.sol
@@ -35,10 +35,6 @@ interface IAaveOracle is IPriceOracle {
   /// @param source The price feed source of the reserve.
   function setReserveSource(uint256 reserveId, address source) external;
 
-  /// @notice Returns the description of the oracle.
-  /// @return The description of the oracle.
-  function DESCRIPTION() external view returns (string memory);
-
   /// @notice Returns the prices of multiple reserves.
   /// @param reserveIds The identifiers of the reserves.
   /// @return prices The prices of the reserves.
@@ -50,4 +46,8 @@ interface IAaveOracle is IPriceOracle {
   /// @param reserveId The identifier of the reserve.
   /// @return source The price feed source of the reserve.
   function getReserveSource(uint256 reserveId) external view returns (address);
+
+  /// @notice Returns the description of the oracle.
+  /// @return The description of the oracle.
+  function DESCRIPTION() external view returns (string memory);
 }

--- a/src/spoke/interfaces/ISpokeBase.sol
+++ b/src/spoke/interfaces/ISpokeBase.sol
@@ -125,6 +125,46 @@ interface ISpokeBase {
     uint256 debtToCover
   ) external;
 
+  /// @notice Returns the total amount of supplied assets of a given reserve.
+  /// @param reserveId The identifier of the reserve.
+  /// @return The amount of supplied assets.
+  function getReserveSuppliedAssets(uint256 reserveId) external view returns (uint256);
+
+  /// @notice Returns the total amount of supplied shares of a given reserve.
+  /// @dev It reverts if the reserve associated with the given reserve identifier is not listed.
+  /// @param reserveId The identifier of the reserve.
+  /// @return The amount of supplied shares.
+  function getReserveSuppliedShares(uint256 reserveId) external view returns (uint256);
+
+  /// @notice Returns the debt of a given reserve.
+  /// @dev It reverts if the reserve associated with the given reserve identifier is not listed.
+  /// @dev The total debt of the reserve is the sum of drawn debt and premium debt.
+  /// @param reserveId The identifier of the reserve.
+  /// @return The amount of drawn debt.
+  /// @return The amount of premium debt.
+  function getReserveDebt(uint256 reserveId) external view returns (uint256, uint256);
+
+  /// @notice Returns the total debt of a given reserve.
+  /// @dev It reverts if the reserve associated with the given reserve identifier is not listed.
+  /// @dev The total debt of the reserve is the sum of drawn debt and premium debt.
+  /// @param reserveId The identifier of the reserve.
+  /// @return The total debt amount.
+  function getReserveTotalDebt(uint256 reserveId) external view returns (uint256);
+
+  /// @notice Returns the amount of assets supplied by a specific user for a given reserve.
+  /// @dev It reverts if the reserve associated with the given reserve identifier is not listed.
+  /// @param reserveId The identifier of the reserve.
+  /// @param user The address of the user.
+  /// @return The amount of assets supplied by the user.
+  function getUserSuppliedAssets(uint256 reserveId, address user) external view returns (uint256);
+
+  /// @notice Returns the amount of shares supplied by a specific user for a given reserve.
+  /// @dev It reverts if the reserve associated with the given reserve identifier is not listed.
+  /// @param reserveId The identifier of the reserve.
+  /// @param user The address of the user.
+  /// @return The amount of shares supplied by the user.
+  function getUserSuppliedShares(uint256 reserveId, address user) external view returns (uint256);
+
   /// @notice Returns the debt of a specific user for a given reserve.
   /// @dev It reverts if the reserve associated with the given reserve identifier is not listed.
   /// @dev The total debt of the user is the sum of drawn debt and premium debt.
@@ -141,44 +181,4 @@ interface ISpokeBase {
   /// @param user The address of the user.
   /// @return The total debt amount.
   function getUserTotalDebt(uint256 reserveId, address user) external view returns (uint256);
-
-  /// @notice Returns the total amount of supplied assets of a given reserve.
-  /// @param reserveId The identifier of the reserve.
-  /// @return The amount of supplied assets.
-  function getReserveSuppliedAssets(uint256 reserveId) external view returns (uint256);
-
-  /// @notice Returns the total amount of supplied shares of a given reserve.
-  /// @dev It reverts if the reserve associated with the given reserve identifier is not listed.
-  /// @param reserveId The identifier of the reserve.
-  /// @return The amount of supplied shares.
-  function getReserveSuppliedShares(uint256 reserveId) external view returns (uint256);
-
-  /// @notice Returns the amount of assets supplied by a specific user for a given reserve.
-  /// @dev It reverts if the reserve associated with the given reserve identifier is not listed.
-  /// @param reserveId The identifier of the reserve.
-  /// @param user The address of the user.
-  /// @return The amount of assets supplied by the user.
-  function getUserSuppliedAssets(uint256 reserveId, address user) external view returns (uint256);
-
-  /// @notice Returns the amount of shares supplied by a specific user for a given reserve.
-  /// @dev It reverts if the reserve associated with the given reserve identifier is not listed.
-  /// @param reserveId The identifier of the reserve.
-  /// @param user The address of the user.
-  /// @return The amount of shares supplied by the user.
-  function getUserSuppliedShares(uint256 reserveId, address user) external view returns (uint256);
-
-  /// @notice Returns the debt of a given reserve.
-  /// @dev It reverts if the reserve associated with the given reserve identifier is not listed.
-  /// @dev The total debt of the reserve is the sum of drawn debt and premium debt.
-  /// @param reserveId The identifier of the reserve.
-  /// @return The amount of drawn debt.
-  /// @return The amount of premium debt.
-  function getReserveDebt(uint256 reserveId) external view returns (uint256, uint256);
-
-  /// @notice Returns the total debt of a given reserve.
-  /// @dev It reverts if the reserve associated with the given reserve identifier is not listed.
-  /// @dev The total debt of the reserve is the sum of drawn debt and premium debt.
-  /// @param reserveId The identifier of the reserve.
-  /// @return The total debt amount.
-  function getReserveTotalDebt(uint256 reserveId) external view returns (uint256);
 }


### PR DESCRIPTION
- Functions are grouped by category (asset, spoke, user) and target user (DAO, user).
- Getters of constants/immutable variables are places at the bottom.
- Reorder of functions based on [Solidity style guidelines.](https://docs.soliditylang.org/en/latest/style-guide.html#order-of-functions)

Changes:
- `_isPositionManager` internal function modifier changed from `private` to `internal`.
- A handful of getter functions were removed from `IHub`, because they were part of `IHubBase` already (dup).