### PR TITLE
chore: add negative case for coverage

### DIFF
--- a/tests/unit/MathUtils.t.sol
+++ b/tests/unit/MathUtils.t.sol
@@ -48,6 +48,25 @@ contract MathUtilsTest is Base {
     MathUtils.calculateLinearInterest(uint96(vm.randomUint()), currentTimestamp + 1);
   }
 
+  function test_calculateLinearInterest_add_edge() public {
+    uint96 rate = type(uint96).max;
+    uint32 previousTimestamp = 0;
+    uint256 skipTime = type(uint32).max;
+
+    vm.warp(skipTime);
+    assertEq(
+      MathUtils.calculateLinearInterest(rate, previousTimestamp),
+      1e27 + (uint256(rate) * uint256(skipTime)) / 365 days
+    );
+
+    skipTime = type(uint128).max;
+    vm.warp(skipTime);
+    assertEq(
+      MathUtils.calculateLinearInterest(rate, previousTimestamp),
+      1e27 + (uint256(rate) * uint256(skipTime)) / 365 days
+    );
+  }
+
   function test_min(uint256 a, uint256 b) public pure {
     assertEq(MathUtils.min(a, b), a < b ? a : b);
   }


### PR DESCRIPTION
Adds edge case tests for `calculateLinearInterest` function to complete code coverage