### PR TITLE
fix: Enforce 6 minimum decimals for Hub assets

### DIFF
--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -32,7 +32,7 @@ contract Hub is IHub, AccessManaged {
   uint8 public constant MAX_ALLOWED_UNDERLYING_DECIMALS = 18;
 
   /// @inheritdoc IHub
-  uint8 public constant MIN_ALLOWED_UNDERLYING_DECIMALS = 5;
+  uint8 public constant MIN_ALLOWED_UNDERLYING_DECIMALS = 6;
 
   /// @inheritdoc IHub
   uint56 public constant MAX_ALLOWED_SPOKE_CAP = type(uint56).max;

--- a/tests/Constants.sol
+++ b/tests/Constants.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 library Constants {
   /// @dev Hub Constants
   uint8 public constant MAX_ALLOWED_UNDERLYING_DECIMALS = 18;
-  uint8 public constant MIN_ALLOWED_UNDERLYING_DECIMALS = 5;
+  uint8 public constant MIN_ALLOWED_UNDERLYING_DECIMALS = 6;
   uint56 public constant MAX_ALLOWED_SPOKE_CAP = type(uint56).max;
 
   /// @dev Spoke Constants


### PR DESCRIPTION
Sets the minimum decimals of a Hub's asset to 6.
#842 set the minimum decimals to 5, but it should be 6.

This adds consistency with V3. 