### PR TITLE
fix : missing fuzz param check in GatewayBase tests

### DIFF
--- a/tests/unit/misc/GatewayBase.t.sol
+++ b/tests/unit/misc/GatewayBase.t.sol
@@ -27,6 +27,7 @@ contract GatewayBaseTest is Base {
   }
 
   function test_registerSpoke_fuzz(address newSpoke) public {
+    vm.assume(newSpoke != address(0));
     assertFalse(gateway.isSpokeRegistered(newSpoke));
 
     vm.expectEmit(address(gateway));


### PR DESCRIPTION
In `GatewayBase.t.sol:test_registerSpoke_fuzz()`, missing `vm.assume(newSpoke != address(0));` to prevent revert.