### PR TITLE
feat: Limit number of spoke reserves via spoke configurator

### DIFF
--- a/src/spoke/SpokeConfigurator.sol
+++ b/src/spoke/SpokeConfigurator.sol
@@ -73,7 +73,7 @@ contract SpokeConfigurator is Ownable2Step, ISpokeConfigurator {
   /// @inheritdoc ISpokeConfigurator
   function updateMaxReserves(address spoke, uint256 maxReserves) external onlyOwner {
     _maxReserves[spoke] = maxReserves;
-    emit MaxReservesUpdated(spoke, maxReserves);
+    emit UpdateMaxReserves(spoke, maxReserves);
   }
 
   /// @inheritdoc ISpokeConfigurator

--- a/src/spoke/interfaces/ISpokeConfigurator.sol
+++ b/src/spoke/interfaces/ISpokeConfigurator.sol
@@ -11,7 +11,7 @@ interface ISpokeConfigurator {
   /// @notice Emitted when the maximum allowed number of reserves for a spoke is updated.
   /// @param spoke The address of the spoke.
   /// @param maxReserves The new maximum number of reserves.
-  event MaxReservesUpdated(address spoke, uint256 maxReserves);
+  event UpdateMaxReserves(address spoke, uint256 maxReserves);
 
   /// @dev Thrown upon adding a reserve when the maximum allowed number of reserves is already reached.
   /// @param spoke The address of the spoke.

--- a/tests/unit/SpokeConfigurator.t.sol
+++ b/tests/unit/SpokeConfigurator.t.sol
@@ -167,7 +167,7 @@ contract SpokeConfiguratorTest is SpokeBase {
   function test_updateMaxReserves() public {
     uint256 newMaxReserves = vm.randomUint();
     vm.expectEmit(address(spokeConfigurator));
-    emit ISpokeConfigurator.MaxReservesUpdated(spokeAddr, newMaxReserves);
+    emit ISpokeConfigurator.UpdateMaxReserves(spokeAddr, newMaxReserves);
     vm.prank(SPOKE_CONFIGURATOR_ADMIN);
     spokeConfigurator.updateMaxReserves(spokeAddr, newMaxReserves);
 


### PR DESCRIPTION
* Enforces a limit on the spoke configurator such that when a reserve is added to a spoke, the operation reverts if that additional reserve would exceed the allowed limit on the spoke
* The owner of the spoke configurator can configure the limit of reserves per each spoke

The motivation for this is that if a reserve has an arbitrary number of spokes (and we do not enforce limits on numbers of collateral on the user level), a user can enable so many collaterals that it causes any operations on their position to fail because they exceed gas limits. The main cause of this is the sorting algorithm involved in calculating a user's risk premium. Indeed, analysis shows that 166 collaterals is the limit where calculating risk premium succeeds, but 167 fails. The other operations such as supplying, borrowing, or liquidating will still succeed and are only in the realm of 17m gas, vs the limit of 45m. The analysis was performed for the worst case of the quicksort algorithm, in which the collaterals are already in sorted order (of collateral risk).

Such analysis should be performed on each spoke implementation to determine the appropriate reserve limit for each spoke

closes https://github.com/aave/aave-v4/issues/734