### PR TITLE
opt: minor extsloads opt 

### DIFF
--- a/src/utils/ExtSload.sol
+++ b/src/utils/ExtSload.sol
@@ -17,7 +17,8 @@ abstract contract ExtSload is IExtSload {
 
   /// @inheritdoc IExtSload
   function extSloads(bytes32[] calldata slots) external view returns (bytes32[] memory) {
-    assembly ('memory-safe') {
+    // @dev we disregard solidity memory conventions since we take control of entire execution
+    assembly {
       mstore(0x00, 0x20) // to abi-encode response, the array will be found at the next word
       mstore(0x20, slots.length) // set the length of dynamic array
       let start := 0x40 // start of the array


### PR DESCRIPTION
saves 29 bytes in code size

opt: starts writing response from mem 0 instead of the next fmp; this is ok because we never read this memory and always write to it 