### PR TITLE
fix: Remove Spoke reserve getters

### DIFF
--- a/src/spoke/Spoke.sol
+++ b/src/spoke/Spoke.sol
@@ -6,7 +6,9 @@ import {SafeCast} from 'src/dependencies/openzeppelin/SafeCast.sol';
 import {SafeERC20, IERC20} from 'src/dependencies/openzeppelin/SafeERC20.sol';
 import {IERC20Permit} from 'src/dependencies/openzeppelin/IERC20Permit.sol';
 import {SignatureChecker} from 'src/dependencies/openzeppelin/SignatureChecker.sol';
-import {AccessManagedUpgradeable} from 'src/dependencies/openzeppelin-upgradeable/AccessManagedUpgradeable.sol';
+import {
+  AccessManagedUpgradeable
+} from 'src/dependencies/openzeppelin-upgradeable/AccessManagedUpgradeable.sol';
 import {EIP712} from 'src/dependencies/solady/EIP712.sol';
 import {MathUtils} from 'src/libraries/math/MathUtils.sol';
 import {PercentageMath} from 'src/libraries/math/PercentageMath.sol';
@@ -516,30 +518,6 @@ abstract contract Spoke is ISpoke, Multicall, NoncesKeyed, AccessManagedUpgradea
   /// @inheritdoc ISpoke
   function getReserveCount() external view returns (uint256) {
     return _reserveCount;
-  }
-
-  /// @inheritdoc ISpokeBase
-  function getReserveSuppliedAssets(uint256 reserveId) external view returns (uint256) {
-    Reserve storage reserve = _getReserve(reserveId);
-    return reserve.hub.getSpokeAddedAssets(reserve.assetId, address(this));
-  }
-
-  /// @inheritdoc ISpokeBase
-  function getReserveSuppliedShares(uint256 reserveId) external view returns (uint256) {
-    Reserve storage reserve = _getReserve(reserveId);
-    return reserve.hub.getSpokeAddedShares(reserve.assetId, address(this));
-  }
-
-  /// @inheritdoc ISpokeBase
-  function getReserveDebt(uint256 reserveId) external view returns (uint256, uint256) {
-    Reserve storage reserve = _getReserve(reserveId);
-    return reserve.hub.getSpokeOwed(reserve.assetId, address(this));
-  }
-
-  /// @inheritdoc ISpokeBase
-  function getReserveTotalDebt(uint256 reserveId) external view returns (uint256) {
-    Reserve storage reserve = _getReserve(reserveId);
-    return reserve.hub.getSpokeTotalOwed(reserve.assetId, address(this));
   }
 
   /// @inheritdoc ISpoke

--- a/src/spoke/TreasurySpoke.sol
+++ b/src/spoke/TreasurySpoke.sol
@@ -98,24 +98,8 @@ contract TreasurySpoke is ITreasurySpoke, Ownable2Step {
   function getUserPremiumDebtRay(uint256, address) external pure returns (uint256) {}
 
   /// @inheritdoc ISpokeBase
-  function getReserveSuppliedAssets(uint256 reserveId) external view returns (uint256) {
-    return HUB.getSpokeAddedAssets(reserveId, address(this));
-  }
-
-  /// @inheritdoc ISpokeBase
-  function getReserveSuppliedShares(uint256 reserveId) external view returns (uint256) {
-    return HUB.getSpokeAddedShares(reserveId, address(this));
-  }
-
-  /// @inheritdoc ISpokeBase
   function getUserSuppliedAssets(uint256, address) external pure returns (uint256) {}
 
   /// @inheritdoc ISpokeBase
   function getUserSuppliedShares(uint256, address) external pure returns (uint256) {}
-
-  /// @inheritdoc ISpokeBase
-  function getReserveDebt(uint256) external pure returns (uint256, uint256) {}
-
-  /// @inheritdoc ISpokeBase
-  function getReserveTotalDebt(uint256) external pure returns (uint256) {}
 }

--- a/src/spoke/interfaces/ISpokeBase.sol
+++ b/src/spoke/interfaces/ISpokeBase.sol
@@ -169,32 +169,6 @@ interface ISpokeBase {
     bool receiveShares
   ) external;
 
-  /// @notice Returns the total amount of supplied assets of a given reserve.
-  /// @param reserveId The identifier of the reserve.
-  /// @return The amount of supplied assets.
-  function getReserveSuppliedAssets(uint256 reserveId) external view returns (uint256);
-
-  /// @notice Returns the total amount of supplied shares of a given reserve.
-  /// @dev It reverts if the reserve associated with the given reserve identifier is not listed.
-  /// @param reserveId The identifier of the reserve.
-  /// @return The amount of supplied shares.
-  function getReserveSuppliedShares(uint256 reserveId) external view returns (uint256);
-
-  /// @notice Returns the debt of a given reserve.
-  /// @dev It reverts if the reserve associated with the given reserve identifier is not listed.
-  /// @dev The total debt of the reserve is the sum of drawn debt and premium debt.
-  /// @param reserveId The identifier of the reserve.
-  /// @return The amount of drawn debt.
-  /// @return The amount of premium debt.
-  function getReserveDebt(uint256 reserveId) external view returns (uint256, uint256);
-
-  /// @notice Returns the total debt of a given reserve.
-  /// @dev It reverts if the reserve associated with the given reserve identifier is not listed.
-  /// @dev The total debt of the reserve is the sum of drawn debt and premium debt.
-  /// @param reserveId The identifier of the reserve.
-  /// @return The total debt amount.
-  function getReserveTotalDebt(uint256 reserveId) external view returns (uint256);
-
   /// @notice Returns the amount of assets supplied by a specific user for a given reserve.
   /// @dev It reverts if the reserve associated with the given reserve identifier is not listed.
   /// @param reserveId The identifier of the reserve.


### PR DESCRIPTION
This draft implementation gives a sense of the savings on bytecode size we could get by removing auxiliary reserve getters from the Spoke. They are only calling the `Hub` contract, so this is actually more efficient. In case this creates any ux friction, we can consider creating an adapter contract to expose all Spoke information in only one place.

_Bytecode size from 24,523 to 23,870_