### PR TITLE
Fix TreasurySpoke getters to revert

### DIFF
--- a/src/spoke/TreasurySpoke.sol
+++ b/src/spoke/TreasurySpoke.sol
@@ -89,13 +89,19 @@ contract TreasurySpoke is ITreasurySpoke, Ownable2Step {
   }
 
   /// @inheritdoc ISpokeBase
-  function getUserDebt(uint256, address) external pure returns (uint256, uint256) {}
+  function getUserDebt(uint256, address) external pure returns (uint256, uint256) {
+    revert UnsupportedAction();
+  }
 
   /// @inheritdoc ISpokeBase
-  function getUserTotalDebt(uint256, address) external pure returns (uint256) {}
+  function getUserTotalDebt(uint256, address) external pure returns (uint256) {
+    revert UnsupportedAction();
+  }
 
   /// @inheritdoc ISpokeBase
-  function getUserPremiumDebtRay(uint256, address) external pure returns (uint256) {}
+  function getUserPremiumDebtRay(uint256, address) external pure returns (uint256) {
+    revert UnsupportedAction();
+  }
 
   /// @inheritdoc ISpokeBase
   function getReserveSuppliedAssets(uint256 reserveId) external view returns (uint256) {
@@ -108,14 +114,22 @@ contract TreasurySpoke is ITreasurySpoke, Ownable2Step {
   }
 
   /// @inheritdoc ISpokeBase
-  function getUserSuppliedAssets(uint256, address) external pure returns (uint256) {}
+  function getUserSuppliedAssets(uint256, address) external pure returns (uint256) {
+    revert UnsupportedAction();
+  }
 
   /// @inheritdoc ISpokeBase
-  function getUserSuppliedShares(uint256, address) external pure returns (uint256) {}
+  function getUserSuppliedShares(uint256, address) external pure returns (uint256) {
+    revert UnsupportedAction();
+  }
 
   /// @inheritdoc ISpokeBase
-  function getReserveDebt(uint256) external pure returns (uint256, uint256) {}
+  function getReserveDebt(uint256) external pure returns (uint256, uint256) {
+    revert UnsupportedAction();
+  }
 
   /// @inheritdoc ISpokeBase
-  function getReserveTotalDebt(uint256) external pure returns (uint256) {}
+  function getReserveTotalDebt(uint256) external pure returns (uint256) {
+    revert UnsupportedAction();
+  }
 }


### PR DESCRIPTION
This change updates TreasurySpoke to explicitly revert for unsupported ISpokeBase getters instead of returning default zero values. 
That prevents silent, misleading reads and aligns behavior with the contract’s intent (TreasurySpoke isn’t a full Spoke). 
This makes integrations safer by failing fast when unsupported getters are called.