### PR TITLE
feat(spoke): expose ownership interface on TreasurySpoke

### DIFF
--- a/src/spoke/interfaces/ITreasurySpoke.sol
+++ b/src/spoke/interfaces/ITreasurySpoke.sol
@@ -4,7 +4,18 @@ pragma solidity ^0.8.0;
 /// @title ITreasurySpoke
 /// @author Aave Labs
 /// @notice Interface for the TreasurySpoke.
-interface ITreasurySpoke {
+interface IOwnable {
+  /// @notice Returns the current owner.
+  function owner() external view returns (address);
+
+  /// @notice Transfers ownership to a new owner.
+  function transferOwnership(address newOwner) external;
+
+  /// @notice Renounces ownership of the contract.
+  function renounceOwnership() external;
+}
+
+interface ITreasurySpoke is IOwnable {
   /// @notice Supplies a specified amount of the underlying asset to the specified Hub.
   /// @dev The Spoke pulls the underlying asset from the caller, so prior approval is required.
   /// @param hub The address of the Hub.

--- a/tests/contracts/treasury-spoke/TreasurySpoke.Upgradeable.t.sol
+++ b/tests/contracts/treasury-spoke/TreasurySpoke.Upgradeable.t.sol
@@ -57,6 +57,7 @@ contract TreasurySpokeUpgradeableTest is Base {
 
     assertEq(_getProxyInitializedVersion(address(proxy)), revision);
     assertEq(Ownable2Step(address(proxy)).owner(), TREASURY_ADMIN);
+    assertEq(ITreasurySpoke(address(proxy)).owner(), TREASURY_ADMIN);
   }
 
   function test_proxy_reinitialization_fuzz(uint64 initialRevision) public {


### PR DESCRIPTION
Add IOwnable to ITreasurySpoke and verify owner() is available through the interface.

Fixes #1283 