### PR TITLE
Added IOwnable interface to support integrations

### DIFF
--- a/src/interfaces/IOwnable.sol
+++ b/src/interfaces/IOwnable.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: LicenseRef-BUSL
+pragma solidity 0.8.28;
+
+/// @title IOwnable
+/// @notice interface for Ownable to support integrations
+interface IOwnable {
+    ///@notice function that returns owner address
+    function owner() external view returns(address);
+}

--- a/src/spoke/TreasurySpoke.sol
+++ b/src/spoke/TreasurySpoke.sol
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: LicenseRef-BUSL
 pragma solidity 0.8.28;
 
+/// OwnableUpgradeable is only imported to override function owner defined in IOwnable.sol
+import {OwnableUpgradeable} from 'src/dependencies/openzeppelin-upgradeable/OwnableUpgradeable.sol';
 import {Ownable2StepUpgradeable} from 'src/dependencies/openzeppelin-upgradeable/Ownable2StepUpgradeable.sol';
 import {SafeERC20, IERC20} from 'src/dependencies/openzeppelin/SafeERC20.sol';
 import {MathUtils} from 'src/libraries/math/MathUtils.sol';
 import {IHubBase} from 'src/hub/interfaces/IHubBase.sol';
+/// IOwnable is only imported to override function owner defined in IOwnable.sol
+import {IOwnable} from 'src/interfaces/IOwnable.sol';
 import {ITreasurySpoke} from 'src/spoke/interfaces/ITreasurySpoke.sol';
 
 /// @title TreasurySpoke
@@ -17,6 +21,14 @@ abstract contract TreasurySpoke is ITreasurySpoke, Ownable2StepUpgradeable {
 
   /// @dev To be overridden by the inheriting TreasurySpoke instance contract.
   function initialize(address owner) external virtual;
+
+  /* function that overrides function owner defined in IOwnable.sol
+  using secure code of OwnableUpgradeable
+  and propagates its effects to contracts inherited from TreasurySpoke */
+  function owner() public view override(IOwnable, OwnableUpgradeable) returns(address) {
+    /// Call secure code of OwnableUpgradeable
+    return super.owner();
+  }
 
   /// @inheritdoc ITreasurySpoke
   function supply(

--- a/src/spoke/interfaces/ITreasurySpoke.sol
+++ b/src/spoke/interfaces/ITreasurySpoke.sol
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: LicenseRef-BUSL
 pragma solidity ^0.8.0;
 
+import {IOwnable} from 'src/interfaces/IOwnable.sol';
+
 /// @title ITreasurySpoke
 /// @author Aave Labs
 /// @notice Interface for the TreasurySpoke.
-interface ITreasurySpoke {
+interface ITreasurySpoke is IOwnable {
   /// @notice Supplies a specified amount of the underlying asset to the specified Hub.
   /// @dev The Spoke pulls the underlying asset from the caller, so prior approval is required.
   /// @param hub The address of the Hub.


### PR DESCRIPTION
closes #1283

An IOwnable.sol file has been added as an interface for the owner function, to facilitate integration with those who need to verify the owner.
The interface is inherited from ITreasureSpoke, and the owner() function in TreasurySpoke overrides both the one defined in the IOwnable interface and that of the OwnableUpgradeable module, but calls the module's secure logic to make the interface safe to use and allow the function's effects to be extended to TreasurySpoke and contracts inherited from it.
I preferred to include only the owner() function in IOwnable.sol and not the other functions of the OwnableUpgradeable module because they are important for executable logic and not read-only. However, if different needs arise, I am open to making changes.
The IOwnable.sol file is also designed for all integrations if necessary, not just for TreasurySpoke contract.