### PR TITLE
feat(libraries): add dewadifyUp and rayToBps helpers

### DIFF
--- a/src/libraries/math/WadRayMath.sol
+++ b/src/libraries/math/WadRayMath.sol
@@ -162,6 +162,24 @@ library WadRayMath {
     }
   }
 
+  /// @notice Removes WAD precision from a given value, rounding up.
+  /// @return b = ceil(a / WAD).
+  function dewadifyUp(uint256 a) internal pure returns (uint256 b) {
+    return wadMulUp(a, 1);
+  }
+
+  /// @notice Converts a RAY value to basis points, rounding down.
+  /// @return b = floor(a * PERCENTAGE_FACTOR / RAY).
+  function rayToBpsDown(uint256 a) internal pure returns (uint256 b) {
+    return rayMulDown(a, PERCENTAGE_FACTOR);
+  }
+
+  /// @notice Converts a RAY value to basis points, rounding up.
+  /// @return b = ceil(a * PERCENTAGE_FACTOR / RAY).
+  function rayToBpsUp(uint256 a) internal pure returns (uint256 b) {
+    return rayMulUp(a, PERCENTAGE_FACTOR);
+  }
+
   /// @notice Removes RAY precision from a given value, rounding up.
   /// @return b = ceil(a / RAY).
   function fromRayUp(uint256 a) internal pure returns (uint256 b) {

--- a/tests/contracts/libraries/math/WadRayMath.t.sol
+++ b/tests/contracts/libraries/math/WadRayMath.t.sol
@@ -265,4 +265,45 @@ contract WadRayMathDifferentialTest is Test {
     test_roundRayUp_fuzz(maxA);
     test_roundRayUp_fuzz(maxA + 1);
   }
+
+  function test_dewadifyUp() public view {
+    assertEq(w.dewadifyUp(0), 0);
+    assertEq(w.dewadifyUp(1e18), 1);
+    assertEq(w.dewadifyUp(2.5e18), 3);
+    assertEq(w.dewadifyUp(369), 1);
+  }
+
+  function test_rayToBpsDown() public view {
+    assertEq(w.rayToBpsDown(0), 0);
+    assertEq(w.rayToBpsDown(1e27), 1e4);
+    assertEq(w.rayToBpsDown(0.5e27), 0.5e4);
+  }
+
+  function test_rayToBpsUp() public view {
+    assertEq(w.rayToBpsUp(0), 0);
+    assertEq(w.rayToBpsUp(1e27), 1e4);
+    assertEq(w.rayToBpsUp(0.5e27 + 1), 0.5e4 + 1);
+  }
+
+  function test_fuzz_dewadifyUp(uint256 a) public view {
+    assertEq(w.dewadifyUp(a), w.wadMulUp(a, 1));
+  }
+
+  function test_fuzz_rayToBpsDown(uint256 a) public {
+    if (!(a == 0 || !(a > UINT256_MAX / w.PERCENTAGE_FACTOR()))) {
+      vm.expectRevert();
+      w.rayToBpsDown(a);
+    } else {
+      assertEq(w.rayToBpsDown(a), w.rayMulDown(a, w.PERCENTAGE_FACTOR()));
+    }
+  }
+
+  function test_fuzz_rayToBpsUp(uint256 a) public {
+    if (!(a == 0 || !(a > UINT256_MAX / w.PERCENTAGE_FACTOR()))) {
+      vm.expectRevert();
+      w.rayToBpsUp(a);
+    } else {
+      assertEq(w.rayToBpsUp(a), w.rayMulUp(a, w.PERCENTAGE_FACTOR()));
+    }
+  }
 }

--- a/tests/helpers/mocks/WadRayMathWrapper.sol
+++ b/tests/helpers/mocks/WadRayMathWrapper.sol
@@ -64,6 +64,18 @@ contract WadRayMathWrapper {
     return WadRayMath.fromWadDown(a);
   }
 
+  function dewadifyUp(uint256 a) public pure returns (uint256) {
+    return WadRayMath.dewadifyUp(a);
+  }
+
+  function rayToBpsDown(uint256 a) public pure returns (uint256) {
+    return WadRayMath.rayToBpsDown(a);
+  }
+
+  function rayToBpsUp(uint256 a) public pure returns (uint256) {
+    return WadRayMath.rayToBpsUp(a);
+  }
+
   function fromRayUp(uint256 a) public pure returns (uint256) {
     return WadRayMath.fromRayUp(a);
   }


### PR DESCRIPTION
## Summary
- Add `dewadifyUp`, `rayToBpsDown`, and `rayToBpsUp` to `WadRayMath`.
- Extend wrapper and differential tests for the new helpers.

## Test plan
- [x] `forge test --match-contract WadRayMathDifferentialTest` (23/23 pass)

Fixes #640
