### PR TITLE
Move gas snapshot check to merge CI

### DIFF
--- a/.github/workflows/tests-merge.yml
+++ b/.github/workflows/tests-merge.yml
@@ -27,8 +27,12 @@ jobs:
       - name: Run Forge size
         uses: bgd-labs/github-workflows/.github/actions/foundry-size@main
 
+      - name: Run Gas report
+        uses: bgd-labs/github-workflows/.github/actions/foundry-gas-report@main
+
       - name: Run Forge tests
         id: test
         uses: bgd-labs/github-workflows/.github/actions/foundry-test@main
         with:
           FOUNDRY_PROFILE: ci
+          FORGE_SNAPSHOT_CHECK: true

--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -31,7 +31,6 @@ jobs:
         uses: bgd-labs/github-workflows/.github/actions/foundry-test@main
         with:
           FOUNDRY_PROFILE: pr
-          FORGE_SNAPSHOT_CHECK: true
 
       - name: Upload & Trigger Comment artifact
         uses: bgd-labs/github-workflows/.github/actions/comment-artifact@main


### PR DESCRIPTION
## Summary
- Run the existing Foundry gas report action in the merge workflow.
- Keep PR gas reporting and comment generation while removing PR snapshot enforcement.
- Enforce `FORGE_SNAPSHOT_CHECK` from the merge CI test step.

Fixes #403

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }; puts "YAML OK"' .github/workflows/tests-pr.yml .github/workflows/tests-merge.yml`
- `yarn prettier --check .github/workflows/tests-pr.yml .github/workflows/tests-merge.yml`
- `npx --yes github-actionlint@1.7.12 .github/workflows/tests-pr.yml .github/workflows/tests-merge.yml`
- `git diff --check`

Workflow-only change; no Forge tests were run locally.