### PR TITLE
fix: skip no-op dynamic config refreshes

### DIFF
--- a/src/spoke/Spoke.sol
+++ b/src/spoke/Spoke.sol
@@ -687,7 +687,6 @@ abstract contract Spoke is
     address user
   ) internal returns (UserAccountData memory) {
     UserAccountData memory accountData = _processUserAccountData(user, true);
-    emit RefreshAllUserDynamicConfig(user);
     require(
       accountData.healthFactor >= HEALTH_FACTOR_LIQUIDATION_THRESHOLD,
       HealthFactorBelowThreshold()
@@ -715,6 +714,7 @@ abstract contract Spoke is
     );
     bool borrowing;
     bool collateral;
+    bool dynamicConfigUpdated;
     while (true) {
       (reserveId, borrowing, collateral) = positionStatus.next(reserveId);
       if (reserveId == PositionStatusMap.NOT_FOUND) break;
@@ -723,14 +723,19 @@ abstract contract Spoke is
       Reserve storage reserve = _reserves[reserveId];
 
       uint256 assetPrice = IAaveOracle(ORACLE).getReservePrice(reserveId);
-      uint256 assetDecimals = reserve.decimals;
 
       if (collateral) {
-        uint256 collateralFactor = _dynamicConfig[reserveId][
-          refreshConfig
-            ? (userPosition.dynamicConfigKey = reserve.dynamicConfigKey)
-            : userPosition.dynamicConfigKey
-        ].collateralFactor;
+        if (refreshConfig) {
+          if (userPosition.dynamicConfigKey != reserve.dynamicConfigKey) {
+            userPosition.dynamicConfigKey = reserve.dynamicConfigKey;
+            if (!dynamicConfigUpdated) {
+              dynamicConfigUpdated = true;
+              emit RefreshAllUserDynamicConfig(user);
+            }
+          }
+        }
+        uint256 collateralFactor = _dynamicConfig[reserveId][userPosition.dynamicConfigKey]
+          .collateralFactor;
         if (collateralFactor > 0) {
           uint256 suppliedShares = userPosition.suppliedShares;
           if (suppliedShares > 0) {
@@ -738,7 +743,7 @@ abstract contract Spoke is
             uint256 userCollateralValue = reserve
               .hub
               .previewRemoveByShares(reserve.assetId, suppliedShares)
-              .toValue({decimals: assetDecimals, price: assetPrice});
+              .toValue({decimals: reserve.decimals, price: assetPrice});
             accountData.totalCollateralValue += userCollateralValue;
             collateralInfo.add(
               accountData.activeCollateralCount,
@@ -759,7 +764,7 @@ abstract contract Spoke is
         uint256 debtRay = debtComponents.drawnShares * debtComponents.drawnIndex +
           debtComponents.premiumDebtRay;
         accountData.totalDebtValueRay += debtRay.toValue({
-          decimals: assetDecimals,
+          decimals: reserve.decimals,
           price: assetPrice
         });
         accountData.borrowCount = accountData.borrowCount.uncheckedAdd(1);
@@ -813,7 +818,12 @@ abstract contract Spoke is
   }
 
   function _refreshDynamicConfig(address user, uint256 reserveId) internal {
-    _userPositions[user][reserveId].dynamicConfigKey = _reserves[reserveId].dynamicConfigKey;
+    uint32 dynamicConfigKey = _reserves[reserveId].dynamicConfigKey;
+    UserPosition storage userPosition = _userPositions[user][reserveId];
+    if (userPosition.dynamicConfigKey == dynamicConfigKey) {
+      return;
+    }
+    userPosition.dynamicConfigKey = dynamicConfigKey;
     emit RefreshSingleUserDynamicConfig(user, reserveId);
   }
 

--- a/tests/contracts/position-manager/ConfigPositionManager/ConfigPositionManager.t.sol
+++ b/tests/contracts/position-manager/ConfigPositionManager/ConfigPositionManager.t.sol
@@ -609,24 +609,26 @@ contract ConfigPositionManagerTest is ConfigPositionManagerBaseTest {
     vm.prank(alice);
     positionManager.setCanUpdateUserDynamicConfigPermission(address(spoke1), bob, true);
 
-    vm.expectEmit(address(spoke1));
-    emit ISpoke.RefreshAllUserDynamicConfig(alice);
+    vm.recordLogs();
     vm.expectEmit(address(positionManager));
     emit IConfigPositionManager.UpdateUserDynamicConfigOnBehalfOf(address(spoke1), bob, alice);
     vm.prank(bob);
     positionManager.updateUserDynamicConfigOnBehalfOf(address(spoke1), alice);
+
+    _assertDynamicConfigRefreshEventsNotEmitted();
   }
 
   function test_updateUserDynamicConfigOnBehalfOf_withGlobalPermission() public {
     vm.prank(alice);
     positionManager.setGlobalPermission(address(spoke1), bob, true);
 
-    vm.expectEmit(address(spoke1));
-    emit ISpoke.RefreshAllUserDynamicConfig(alice);
+    vm.recordLogs();
     vm.expectEmit(address(positionManager));
     emit IConfigPositionManager.UpdateUserDynamicConfigOnBehalfOf(address(spoke1), bob, alice);
     vm.prank(bob);
     positionManager.updateUserDynamicConfigOnBehalfOf(address(spoke1), alice);
+
+    _assertDynamicConfigRefreshEventsNotEmitted();
   }
 
   function test_updateUserDynamicConfigOnBehalfOf_revertsWith_CallerNotAllowed() public {

--- a/tests/contracts/position-manager/SignatureGateway/SignatureGateway.t.sol
+++ b/tests/contracts/position-manager/SignatureGateway/SignatureGateway.t.sol
@@ -293,12 +293,11 @@ contract SignatureGatewayTest is SignatureGatewayBaseTest {
     p.nonce = _burnRandomNoncesAtKey(gateway, alice);
     bytes memory signature = _sign(alicePk, _getTypedDataHash(gateway, p));
 
-    vm.expectEmit(address(spoke1));
-    emit ISpoke.RefreshAllUserDynamicConfig(alice);
-
+    vm.recordLogs();
     vm.prank(vm.randomAddress());
     gateway.updateUserDynamicConfigWithSig(p, signature);
 
+    _assertDynamicConfigRefreshEventsNotEmitted();
     _assertNonceIncrement(gateway, alice, p.nonce);
     _assertGatewayHasNoBalanceOrAllowance(spoke1, gateway, alice);
     _assertGatewayHasNoActivePosition(spoke1, gateway);

--- a/tests/contracts/spoke/configuration/Spoke.DynamicConfig.Triggers.t.sol
+++ b/tests/contracts/spoke/configuration/Spoke.DynamicConfig.Triggers.t.sol
@@ -305,6 +305,11 @@ contract SpokeDynamicConfigTriggersTest is Base {
       amount: 1e18,
       onBehalfOf: alice
     });
+    _addDynamicReserveConfig(
+      spoke1,
+      _wethReserveId(spoke1),
+      _getLatestDynamicReserveConfig(spoke1, _wethReserveId(spoke1))
+    );
 
     // when enabling, only the relevant asset is refreshed
     vm.expectEmit(address(spoke1));
@@ -318,14 +323,45 @@ contract SpokeDynamicConfigTriggersTest is Base {
     assertEq(userConfig[_wethReserveId(spoke1)], spokeConfig[_wethReserveId(spoke1)]);
     assertNotEq(abi.encode(userConfig), abi.encode(spokeConfig));
 
-    // when disabling all configs are refreshed
-    vm.expectEmit(address(spoke1));
-    emit ISpoke.RefreshAllUserDynamicConfig(alice);
+    DynamicConfigEntry[] memory beforeDisableConfig = _getUserDynConfigKeys(spoke1, alice);
+
+    // when disabling without stale enabled collateral, no dynamic config refresh is emitted
+    vm.recordLogs();
     vm.prank(alice);
     spoke1.setUsingAsCollateral(_usdxReserveId(spoke1), false, alice);
 
-    assertNotEq(_getUserDynConfigKeys(spoke1, alice), configs);
-    assertEq(_getSpokeDynConfigKeys(spoke1), _getUserDynConfigKeys(spoke1, alice));
+    _assertDynamicConfigRefreshEventsNotEmitted();
+    assertFalse(_isUsingAsCollateral(spoke1, _usdxReserveId(spoke1), alice));
+    assertEq(
+      spoke1.getUserPosition(_usdxReserveId(spoke1), alice).dynamicConfigKey,
+      beforeDisableConfig[_usdxReserveId(spoke1)].key
+    );
+    assertEq(
+      _getUserDynConfigKeys(spoke1, alice, _wethReserveId(spoke1)),
+      _getSpokeDynConfigKeys(spoke1)[_wethReserveId(spoke1)]
+    );
+  }
+
+  function test_usingAsCollateral_doesNotEmitDynamicConfigRefresh_whenConfigIsCurrent() public {
+    uint256 reserveId = _usdxReserveId(spoke1);
+
+    SpokeActions.supply({
+      spoke: spoke1,
+      reserveId: reserveId,
+      caller: alice,
+      amount: 1000e6,
+      onBehalfOf: alice
+    });
+
+    uint32 dynamicConfigKey = spoke1.getUserPosition(reserveId, alice).dynamicConfigKey;
+
+    vm.recordLogs();
+    vm.prank(alice);
+    spoke1.setUsingAsCollateral(reserveId, true, alice);
+
+    _assertDynamicConfigRefreshEventsNotEmitted();
+    assertTrue(_isUsingAsCollateral(spoke1, reserveId, alice));
+    assertEq(spoke1.getUserPosition(reserveId, alice).dynamicConfigKey, dynamicConfigKey);
   }
 
   function test_updateUserDynamicConfig_triggers_dynamicConfigUpdate() public {
@@ -361,6 +397,32 @@ contract SpokeDynamicConfigTriggersTest is Base {
     // user config should change
     assertNotEq(_getUserDynConfigKeys(spoke1, alice), configs);
     assertEq(_getSpokeDynConfigKeys(spoke1), _getUserDynConfigKeys(spoke1, alice));
+  }
+
+  function test_updateUserDynamicConfig_doesNotEmit_whenConfigIsCurrent() public {
+    SpokeActions.supplyCollateral({
+      spoke: spoke1,
+      reserveId: _usdxReserveId(spoke1),
+      caller: alice,
+      amount: 1000e6,
+      onBehalfOf: alice
+    });
+    SpokeActions.supplyCollateral({
+      spoke: spoke1,
+      reserveId: _wethReserveId(spoke1),
+      caller: alice,
+      amount: 1e18,
+      onBehalfOf: alice
+    });
+
+    DynamicConfigEntry[] memory configs = _getUserDynConfigKeys(spoke1, alice);
+
+    vm.recordLogs();
+    vm.prank(alice);
+    spoke1.updateUserDynamicConfig(alice);
+
+    _assertDynamicConfigRefreshEventsNotEmitted();
+    assertEq(_getUserDynConfigKeys(spoke1, alice), configs);
   }
 
   function test_updateUserDynamicConfig_reverts_when_not_authorized(address caller) public {

--- a/tests/helpers/mocks/MockSpoke.sol
+++ b/tests/helpers/mocks/MockSpoke.sol
@@ -57,7 +57,6 @@ contract MockSpoke is Spoke, Test {
 
     uint256 newRiskPremium = _processUserAccountData({user: onBehalfOf, refreshConfig: true})
       .riskPremium;
-    emit RefreshAllUserDynamicConfig(onBehalfOf);
     _notifyRiskPremiumUpdate(onBehalfOf, newRiskPremium);
 
     emit Borrow(reserveId, msg.sender, onBehalfOf, drawnShares, amount);


### PR DESCRIPTION
## Summary
- skip user dynamic config storage writes when the stored key already matches the reserve's latest key
- emit `RefreshAllUserDynamicConfig` and `RefreshSingleUserDynamicConfig` only when a user key actually changes
- add/update coverage for no-op refresh paths through Spoke, ConfigPositionManager, and SignatureGateway

Addresses #530

## Testing
- `yarn lint`
- `forge test --match-path tests/contracts/spoke/configuration/Spoke.DynamicConfig.Triggers.t.sol -vv`
- `forge test --match-path tests/contracts/spoke/misc/Spoke.UserAccountData.t.sol -vv`
- `forge test --match-path tests/contracts/position-manager/ConfigPositionManager/ConfigPositionManager.t.sol --match-test test_updateUserDynamicConfigOnBehalfOf -vv`
- `forge test --match-path tests/contracts/position-manager/SignatureGateway/SignatureGateway.t.sol --match-test test_updateUserDynamicConfigWithSig -vv`
- `forge test --match-path tests/contracts/spoke/position-manager/Spoke.PositionManager.t.sol --match-test test_onlyPositionManager_on_updateUserDynamicConfig -vv`
- `forge build --force --skip 'tests/**/*.sol' --skip 'scripts/**/*.sol'`
- `forge build --sizes --skip 'tests/**/*.sol' --skip 'scripts/**/*.sol'` (`SpokeInstance`: 24,378 bytes, 198-byte margin)
