### PR TITLE
feat: expose oracle base currency metadata

### DIFF
--- a/src/deployments/procedures/deploy/spoke/AaveV4AaveOracleDeployProcedure.sol
+++ b/src/deployments/procedures/deploy/spoke/AaveV4AaveOracleDeployProcedure.sol
@@ -13,6 +13,6 @@ contract AaveV4AaveOracleDeployProcedure is AaveV4DeployProcedureBase {
   /// @return The address of the deployed AaveOracle contract.
   function _deployAaveOracle(uint8 decimals) internal returns (address) {
     require(decimals > 0, 'invalid oracle decimals');
-    return address(new AaveOracle({decimals_: decimals}));
+    return address(new AaveOracle({decimals_: decimals, baseCurrency_: address(0)}));
   }
 }

--- a/src/spoke/AaveOracle.sol
+++ b/src/spoke/AaveOracle.sol
@@ -10,6 +10,12 @@ import {IAaveOracle, IPriceOracle} from 'src/spoke/interfaces/IAaveOracle.sol';
 /// @notice Provides reserve prices.
 /// @dev Oracles are spoke-specific, due to the usage of reserve id as index of the `_sources` mapping.
 contract AaveOracle is IAaveOracle {
+  /// @inheritdoc IAaveOracle
+  address public constant override USD_ADDRESS = address(0);
+
+  /// @inheritdoc IAaveOracle
+  address public immutable override BASE_CURRENCY;
+
   /// @dev The number of decimals for the oracle.
   uint8 private immutable DECIMALS;
 
@@ -25,9 +31,11 @@ contract AaveOracle is IAaveOracle {
   /// @dev Constructor.
   /// @dev `decimals` must match the Spoke's decimals for compatibility.
   /// @param decimals_ The number of decimals for the oracle.
-  constructor(uint8 decimals_) {
+  /// @param baseCurrency_ The base currency used for price quotes. Use `USD_ADDRESS` when quoting in USD.
+  constructor(uint8 decimals_, address baseCurrency_) {
     DEPLOYER = msg.sender;
     DECIMALS = decimals_;
+    BASE_CURRENCY = baseCurrency_;
   }
 
   /// @inheritdoc IAaveOracle

--- a/src/spoke/interfaces/IAaveOracle.sol
+++ b/src/spoke/interfaces/IAaveOracle.sol
@@ -40,6 +40,13 @@ interface IAaveOracle is IPriceOracle {
   /// @dev Thrown when the Spoke's oracle does not match the current oracle.
   error OracleMismatch();
 
+  /// @notice Returns the sentinel address used when prices are denominated in USD.
+  /// @dev Matches the Aave V3 convention: address(0) represents USD.
+  function USD_ADDRESS() external view returns (address);
+
+  /// @notice Returns the base currency used for price quotes.
+  function BASE_CURRENCY() external view returns (address);
+
   /// @notice Sets the address of the Spoke.
   /// @dev Can only be called once by the deployer.
   /// @dev The spoke should be set before any other function is called.

--- a/tests/contracts/spoke/AaveOracle.t.sol
+++ b/tests/contracts/spoke/AaveOracle.t.sol
@@ -10,6 +10,7 @@ contract AaveOracleTest is Base {
   AaveOracle public oracle;
 
   uint8 private constant _oracleDecimals = 8;
+  address private constant _baseCurrency = address(0);
 
   address public deployer = makeAddr('DEPLOYER');
 
@@ -25,7 +26,7 @@ contract AaveOracleTest is Base {
     super.setUp();
 
     vm.startPrank(deployer);
-    oracle = new AaveOracle(_oracleDecimals);
+    oracle = new AaveOracle(_oracleDecimals, _baseCurrency);
     spoke1 = ISpoke(
       address(
         AaveV4TestOrchestration.deploySpokeImplementation(
@@ -40,18 +41,21 @@ contract AaveOracleTest is Base {
 
   function test_constructor() public {
     vm.prank(deployer);
-    oracle = new AaveOracle(_oracleDecimals);
+    oracle = new AaveOracle(_oracleDecimals, _baseCurrency);
 
     assertEq(oracle.spoke(), address(0));
+    assertEq(oracle.USD_ADDRESS(), address(0));
+    assertEq(oracle.BASE_CURRENCY(), _baseCurrency);
     test_decimals();
   }
 
-  function test_fuzz_constructor(uint8 decimals) public {
+  function test_fuzz_constructor(uint8 decimals, address baseCurrency) public {
     decimals = bound(decimals, 0, 18).toUint8();
-    oracle = new AaveOracle(decimals);
+    oracle = new AaveOracle(decimals, baseCurrency);
 
     assertEq(oracle.spoke(), address(0));
     assertEq(oracle.decimals(), decimals);
+    assertEq(oracle.BASE_CURRENCY(), baseCurrency);
   }
 
   function test_decimals() public view {
@@ -81,7 +85,7 @@ contract AaveOracleTest is Base {
 
   function test_setSpoke() public {
     vm.startPrank(deployer);
-    oracle = new AaveOracle(_oracleDecimals);
+    oracle = new AaveOracle(_oracleDecimals, _baseCurrency);
 
     address newSpoke = address(
       AaveV4TestOrchestration.deploySpokeImplementation(
@@ -144,10 +148,10 @@ contract AaveOracleTest is Base {
 
   function test_setReserveSource_revertsWith_OracleMismatch() public {
     vm.startPrank(deployer);
-    IAaveOracle newOracle = IAaveOracle(new AaveOracle(_oracleDecimals));
+    IAaveOracle newOracle = IAaveOracle(new AaveOracle(_oracleDecimals, _baseCurrency));
 
     // set new spoke to a separate oracle
-    address mismatchOracle = address(new AaveOracle(_oracleDecimals));
+    address mismatchOracle = address(new AaveOracle(_oracleDecimals, _baseCurrency));
     address newSpoke = address(
       AaveV4TestOrchestration.deploySpokeImplementation(
         mismatchOracle,

--- a/tests/deployments/batches/AaveV4SpokeInstanceBatch.t.sol
+++ b/tests/deployments/batches/AaveV4SpokeInstanceBatch.t.sol
@@ -41,6 +41,10 @@ contract AaveV4SpokeInstanceBatchTest is BatchBaseTest {
   function test_oracleWiring() public view {
     assertEq(IPriceOracle(report.aaveOracle).spoke(), report.spokeProxy);
     assertEq(IPriceOracle(report.aaveOracle).decimals(), 8);
+    assertEq(
+      IAaveOracle(report.aaveOracle).BASE_CURRENCY(),
+      IAaveOracle(report.aaveOracle).USD_ADDRESS()
+    );
   }
 
   function test_revert_zeroAuthority() public {

--- a/tests/deployments/batches/BatchBase.t.sol
+++ b/tests/deployments/batches/BatchBase.t.sol
@@ -30,6 +30,7 @@ import {AssetInterestRateStrategy} from 'src/hub/AssetInterestRateStrategy.sol';
 import {IAccessManagerEnumerable} from 'src/access/interfaces/IAccessManagerEnumerable.sol';
 import {TreasurySpoke} from 'src/spoke/TreasurySpoke.sol';
 import {ISpoke} from 'src/spoke/interfaces/ISpoke.sol';
+import {IAaveOracle} from 'src/spoke/interfaces/IAaveOracle.sol';
 import {IPriceOracle} from 'src/spoke/interfaces/IPriceOracle.sol';
 
 contract BatchBaseTest is Create2TestHelper {

--- a/tests/deployments/procedures/ProceduresBase.t.sol
+++ b/tests/deployments/procedures/ProceduresBase.t.sol
@@ -66,7 +66,7 @@ contract ProceduresBase is Create2TestHelper {
     hubBytecode = vm.getCode('src/hub/instances/HubInstance.sol:HubInstance');
     spokeBytecode = vm.getCode('src/spoke/instances/SpokeInstance.sol:SpokeInstance');
     accessManager = address(new AccessManagerEnumerable(accessManagerAdmin));
-    aaveOracle = address(new AaveOracle(oracleDecimals));
+    aaveOracle = address(new AaveOracle(oracleDecimals, address(0)));
     salt = keccak256('testSalt');
   }
 

--- a/tests/deployments/procedures/deploy/spoke/AaveV4AaveOracleDeployProcedure.t.sol
+++ b/tests/deployments/procedures/deploy/spoke/AaveV4AaveOracleDeployProcedure.t.sol
@@ -14,6 +14,7 @@ contract AaveV4AaveOracleDeployProcedureTest is ProceduresBase {
     address oracle = aaveV4AaveOracleDeployProcedureWrapper.deployAaveOracle(oracleDecimals);
     assertNotEq(oracle, address(0));
     assertEq(IAaveOracle(oracle).decimals(), oracleDecimals);
+    assertEq(IAaveOracle(oracle).BASE_CURRENCY(), IAaveOracle(oracle).USD_ADDRESS());
   }
 
   function test_deployAaveOracle_reverts_inputValidation() public {

--- a/tests/helpers/spoke/SetupHelpers.sol
+++ b/tests/helpers/spoke/SetupHelpers.sol
@@ -431,7 +431,7 @@ abstract contract SetupHelpers is CheckedActions, ConfigHelpers, MockHelpers {
     address deployer = makeAddr('deployer');
 
     vm.startPrank(deployer);
-    IAaveOracle oracle = new AaveOracle(8);
+    IAaveOracle oracle = new AaveOracle(8, address(0));
 
     ISpoke spoke = ISpoke(
       AaveV4TestOrchestration.proxify(


### PR DESCRIPTION
## Summary
- expose `USD_ADDRESS` and `BASE_CURRENCY` on `IAaveOracle`/`AaveOracle`
- initialize `BASE_CURRENCY` from the oracle constructor while keeping current deploy flow on the USD sentinel
- cover oracle constructor metadata and deployment wiring in tests

Addresses #510

## Notes
This intentionally does not add special-case price logic for the base currency. Base reserve pricing should still come from a registered price source, matching the direction discussed in #478.

## Testing
- `yarn lint`
- `forge test --match-path tests/contracts/spoke/AaveOracle.t.sol -vv`
- `forge test --match-path tests/deployments/procedures/deploy/spoke/AaveV4AaveOracleDeployProcedure.t.sol -vv`
- `forge test --match-path tests/deployments/batches/AaveV4SpokeInstanceBatch.t.sol -vv`
- `forge build --force --skip 'tests/**/*.sol' --skip 'scripts/**/*.sol'`
- `forge build --sizes --skip 'tests/**/*.sol' --skip 'scripts/**/*.sol'`
