### PR TITLE
feat: json script and test for PMs update version 0.5.12 (review only)

### DIFF
--- a/scripts/PositionManagersUpdateJson.s.sol
+++ b/scripts/PositionManagersUpdateJson.s.sol
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: LicenseRef-BUSL
+pragma solidity 0.8.28;
+
+import {Script} from 'forge-std/Script.sol';
+import {console2 as console} from 'forge-std/console2.sol';
+
+import {ISpokeConfigurator} from 'src/spoke/interfaces/ISpokeConfigurator.sol';
+import {IPositionManagerBase} from 'src/position-manager/interfaces/IPositionManagerBase.sol';
+import {IAccessManager} from 'src/dependencies/openzeppelin/IAccessManager.sol';
+import {Bytes} from 'src/dependencies/openzeppelin/Bytes.sol';
+
+import {
+  ChainConfig,
+  PositionManagersUpdateUtils
+} from 'scripts/utils/PositionManagersUpdateUtils.sol';
+
+/// @title PositionManagersUpdateJsonBase
+/// @author Aave Labs
+/// @notice Emits the Safe Transaction Builder batch file for the Position Managers update.
+
+abstract contract PositionManagersUpdateJsonBase is Script {
+  /// @notice Thrown when the script runs against a chain other than the one it was built for.
+  error ChainIdMismatch(uint256 expected, uint256 actual);
+
+  /// @notice Thrown when a Position Manager address is still unset.
+  error PositionManagerAddressZero();
+
+  /// @notice Thrown when `_decode` meets a selector it does not know how to render.
+  error UnsupportedSelector(bytes4 selector);
+
+  /// @notice Builds the batch and writes it to `output/`, ready to import into the Safe.
+  function run() external {
+    ChainConfig memory cfg = _config();
+    require(block.chainid == cfg.chainId, ChainIdMismatch(cfg.chainId, block.chainid));
+    require(
+      cfg.oldPms.length == cfg.newPms.length,
+      PositionManagersUpdateUtils.LengthMismatch(cfg.oldPms.length, cfg.newPms.length)
+    );
+    for (uint256 i; i < cfg.oldPms.length; ++i) {
+      require(cfg.oldPms[i] != address(0), PositionManagerAddressZero());
+    }
+    for (uint256 i; i < cfg.newPms.length; ++i) {
+      require(cfg.newPms[i] != address(0), PositionManagerAddressZero());
+    }
+
+    PositionManagersUpdateUtils.Action[] memory actions = PositionManagersUpdateUtils.buildActions(
+      cfg
+    );
+
+    uint256 createdAt = vm.unixTime();
+
+    string memory json = _buildBatchFile(cfg, actions, createdAt);
+    vm.writeFile(_outputFile(), json);
+    vm.parseJson(vm.readFile(_outputFile()));
+
+    console.log('chain id  : %s', cfg.chainId);
+    console.log('actions   : %s', actions.length);
+    console.log('written to: %s', _outputFile());
+  }
+
+  /// @dev Override to select the chain.
+  function _config() internal pure virtual returns (ChainConfig memory);
+
+  /// @dev Override to set the destination path under `output/`.
+  function _outputFile() internal pure virtual returns (string memory);
+
+  /// @dev Override to set `meta.name`, the label the Safe UI shows for the batch.
+  function _batchName() internal pure virtual returns (string memory);
+
+  // ─────────────────────────── Decoding ─────────────────────────── //
+
+  /// @dev A call rendered as the Transaction Builder describes it, in ABI order.
+  struct DecodedCall {
+    string methodName;
+    string[] inputNames;
+    string[] inputTypes;
+    string[] inputValues;
+  }
+
+  /// @dev Recovers the method signature and argument values from the raw calldata, so the
+  ///      emitted file is derived from the bytes that are actually executed.
+  function _decode(
+    PositionManagersUpdateUtils.Action memory action
+  ) internal pure returns (DecodedCall memory d) {
+    bytes4 selector = bytes4(action.data);
+    bytes memory args = Bytes.slice(action.data, 4);
+
+    if (selector == ISpokeConfigurator.updatePositionManager.selector) {
+      (address spoke, address pm, bool active) = abi.decode(args, (address, address, bool));
+      d.methodName = 'updatePositionManager';
+      d.inputNames = _arr3('spoke', 'positionManager', 'active');
+      d.inputTypes = _arr3('address', 'address', 'bool');
+      d.inputValues = _arr3(_addr(spoke), _addr(pm), active ? 'true' : 'false');
+      return d;
+    }
+
+    if (selector == IPositionManagerBase.registerSpoke.selector) {
+      (address spoke, bool registered) = abi.decode(args, (address, bool));
+      d.methodName = 'registerSpoke';
+      d.inputNames = _arr2('spoke', 'registered');
+      d.inputTypes = _arr2('address', 'bool');
+      d.inputValues = _arr2(_addr(spoke), registered ? 'true' : 'false');
+      return d;
+    }
+
+    if (selector == IAccessManager.grantRole.selector) {
+      (uint64 roleId, address account, uint32 executionDelay) = abi.decode(
+        args,
+        (uint64, address, uint32)
+      );
+      d.methodName = 'grantRole';
+      d.inputNames = _arr3('roleId', 'account', 'executionDelay');
+      d.inputTypes = _arr3('uint64', 'address', 'uint32');
+      d.inputValues = _arr3(vm.toString(roleId), _addr(account), vm.toString(executionDelay));
+      return d;
+    }
+
+    revert UnsupportedSelector(selector);
+  }
+
+  // ─────────────────────── Transaction Builder file ─────────────────────── //
+
+  /// @notice Builds the JSON file that the Safe Transaction Builder can import.
+  /// @param cfg The chainconfig to build for.
+  /// @param actions The ordered action list.
+  /// @param createdAt The timestamp to emit in the file.
+  /// @return The final JSON string.
+  function _buildBatchFile(
+    ChainConfig memory cfg,
+    PositionManagersUpdateUtils.Action[] memory actions,
+    uint256 createdAt
+  ) internal pure returns (string memory) {
+    string memory txs;
+    for (uint256 i; i < actions.length; ++i) {
+      txs = string.concat(txs, i == 0 ? '\n    ' : ',\n    ', _prettyTx(actions[i]));
+    }
+
+    return
+      string.concat(
+        '{\n',
+        '  "version": "1.0",\n',
+        '  "chainId": "',
+        vm.toString(cfg.chainId),
+        '",\n',
+        '  "createdAt": ',
+        vm.toString(createdAt),
+        ',\n',
+        '  "meta": {\n',
+        '    "name": "',
+        _batchName(),
+        '",\n',
+        '    "description": "",\n',
+        '    "txBuilderVersion": "2.0.1",\n',
+        '    "createdFromSafeAddress": "',
+        _addr(PositionManagersUpdateUtils.PROTOCOL_SECURITY_COUNCIL),
+        '",\n',
+        '    "createdFromOwnerAddress": ""\n',
+        '  },\n',
+        '  "transactions": [',
+        txs,
+        '\n  ]\n',
+        '}\n'
+      );
+  }
+
+  /// @notice The readable shape, so a reviewer in the Safe UI sees
+  /// @param action The raw action to render.
+  /// @return The JSON string for the action pretty-printed in the Transaction Builder.
+  function _prettyTx(
+    PositionManagersUpdateUtils.Action memory action
+  ) internal pure returns (string memory) {
+    DecodedCall memory d = _decode(action);
+    (string memory inputs, string memory values) = _inputsJson(d);
+
+    return
+      string.concat(
+        '{\n',
+        '      "to": "',
+        _addr(action.to),
+        '",\n',
+        '      "value": "0",\n',
+        '      "data": null,\n',
+        '      "contractMethod": {\n',
+        '        "inputs": [',
+        inputs,
+        '\n        ],\n',
+        '        "name": "',
+        d.methodName,
+        '",\n',
+        '        "payable": false\n',
+        '      },\n',
+        '      "contractInputsValues": {',
+        values,
+        '\n      }\n',
+        '    }'
+      );
+  }
+
+  /// @notice Renders the per-argument sections of one transaction entry.
+  /// @param d The decoded call to render.
+  /// @return inputs The `contractMethod.inputs` array body.
+  /// @return values The `contractInputsValues` object body.
+  function _inputsJson(
+    DecodedCall memory d
+  ) private pure returns (string memory inputs, string memory values) {
+    for (uint256 i; i < d.inputNames.length; ++i) {
+      inputs = string.concat(
+        inputs,
+        i == 0 ? '\n          ' : ',\n          ',
+        '{"name": "',
+        d.inputNames[i],
+        '", "type": "',
+        d.inputTypes[i],
+        '", "internalType": "',
+        d.inputTypes[i],
+        '"}'
+      );
+      values = string.concat(
+        values,
+        i == 0 ? '\n        ' : ',\n        ',
+        '"',
+        d.inputNames[i],
+        '": "',
+        d.inputValues[i],
+        '"'
+      );
+    }
+  }
+
+  // ─────────────────────────── Small helpers ───────────────────────────
+
+  /// @notice EIP-55 mixed case, the same casing the Transaction Builder writes in its own exports.
+  function _addr(address a) private pure returns (string memory) {
+    return vm.toString(a);
+  }
+
+  /// @notice Builds a `string[]` from its arguments, which Solidity has no literal syntax for.
+  function _arr2(string memory a, string memory b) private pure returns (string[] memory out) {
+    out = new string[](2);
+    out[0] = a;
+    out[1] = b;
+  }
+
+  /// @notice Stands in for the dynamic array literals Solidity does not have.
+  function _arr3(
+    string memory a,
+    string memory b,
+    string memory c
+  ) private pure returns (string[] memory out) {
+    out = new string[](3);
+    out[0] = a;
+    out[1] = b;
+    out[2] = c;
+  }
+}
+
+/// @title GenerateEthereumJson
+/// @author Aave Labs
+/// @notice Ethereum batch. 10 Spokes x 2 Position Managers x 4 changes = 80 actions.
+contract GenerateEthereumJson is PositionManagersUpdateJsonBase {
+  function _config() internal pure override returns (ChainConfig memory) {
+    return PositionManagersUpdateUtils.ethereum();
+  }
+
+  function _outputFile() internal pure override returns (string memory) {
+    return './output/position-managers-update-ethereum.json';
+  }
+
+  function _batchName() internal pure override returns (string memory) {
+    return 'Replace v4 Position Managers (v0.5.12) - Ethereum';
+  }
+}
+
+/// @title GenerateAvalancheJson
+/// @author Aave Labs
+/// @notice Avalanche batch. 1 role grant + 3 Spokes x 2 Position Managers x 4 changes = 25 actions.
+contract GenerateAvalancheJson is PositionManagersUpdateJsonBase {
+  function _config() internal pure override returns (ChainConfig memory) {
+    return PositionManagersUpdateUtils.avalanche();
+  }
+
+  function _outputFile() internal pure override returns (string memory) {
+    return './output/position-managers-update-avalanche.json';
+  }
+
+  function _batchName() internal pure override returns (string memory) {
+    return 'Replace v4 Position Managers (v0.5.12) - Avalanche';
+  }
+}

--- a/scripts/utils/PositionManagersUpdateUtils.sol
+++ b/scripts/utils/PositionManagersUpdateUtils.sol
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: LicenseRef-BUSL
+pragma solidity 0.8.28;
+
+import {ISpokeConfigurator} from 'src/spoke/interfaces/ISpokeConfigurator.sol';
+import {IPositionManagerBase} from 'src/position-manager/interfaces/IPositionManagerBase.sol';
+import {IAccessManager} from 'src/dependencies/openzeppelin/IAccessManager.sol';
+
+/// @notice Per-chain inputs for the Position Managers update batch.
+/// @notice We only need to update TAKER_POSITION_MANAGER and CONFIG_POSITION_MANAGER across all the spokes in Ethereum and Avalanche.
+/// @dev chainId Expected chain, asserted before emitting or executing anything.
+/// @dev accessManager The AccessManager governing the SpokeConfigurator.
+/// @dev spokeConfigurator Entry point for the Spoke side of the handshake.
+/// @dev spokes The Spokes that carry position managers.
+/// @dev spokeNames Labels parallel to `spokes`, used only for logs and for JSON review.
+/// @dev oldPms The Position Managers being replaced.
+/// @dev newPms Their replacements, in the SAME order as `oldPms`.
+/// @dev grantRole400ToSafe Whether the batch must first grant the Safe the
+///      SpokeConfigurator domain admin role. Needed in the case of avalanche and the Safe not having the 400 role`.
+struct ChainConfig {
+  uint256 chainId;
+  address accessManager;
+  address spokeConfigurator;
+  address[] spokes;
+  string[] spokeNames;
+  address[] oldPms;
+  address[] newPms;
+  bool grantRole400ToSafe;
+}
+
+/// @title PositionManagersUpdateUtils
+/// @author Aave Labs
+/// @notice The single source of truth for the Position Managers update batch, executed
+///         directly by the Protocol Security Council Safe.
+///
+/// @dev There is no payload and no Executor involved. `registerSpoke` is `onlyOwner` on the
+///      Position Manager and the Safe is that owner, while the Labs Executor is not — so the
+///      PM half of the handshake cannot be routed through a payload. The Safe does the whole
+///      batch itself in one MultiSend.
+///
+/// @dev The same `buildActions` output feeds two consumers:
+///        1. the tests, which execute it with `vm.prank(PROTOCOL_SECURITY_COUNCIL)` and assert the resulting flags
+///        2. the JSON generator, which emits it for the Safe Transaction Builder
+///      Managing to test exactly the same paylaod that is generated and imported into the Safe.
+library PositionManagersUpdateUtils {
+  /// @notice Thrown when two arrays that have to line up by index do not.
+  error LengthMismatch(uint256 expected, uint256 actual);
+
+  address internal constant PROTOCOL_SECURITY_COUNCIL = 0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9;
+
+  uint64 internal constant SPOKE_CONFIGURATOR_DOMAIN_ADMIN_ROLE = 400;
+
+  /// @param to Target contract of the call.
+  /// @param data Calldata. The only description of the action there is: the JSON generator
+  ///        decodes it to render the human-readable form, so nothing can drift out of sync.
+  struct Action {
+    address to;
+    bytes data;
+  }
+
+  // ───────────────────────────── Ethereum ───────────────────────────── //
+
+  /// @dev The Safe already holds role 400 here (canCall == true, delay 0), so no grant is
+  ///      needed. 10 Spokes x 2 Position Managers x 4 changes = 80 actions.
+  function ethereum() internal pure returns (ChainConfig memory cfg) {
+    address[] memory spokes = new address[](10);
+    string[] memory names = new string[](10);
+
+    spokes[0] = 0x94e7A5dCbE816e498b89aB752661904E2F56c485;
+    names[0] = 'MAIN_SPOKE';
+
+    spokes[1] = 0x973a023A77420ba610f06b3858aD991Df6d85A08;
+    names[1] = 'BLUECHIP_SPOKE';
+
+    spokes[2] = 0x58131E79531caB1d52301228d1f7b842F26B9649;
+    names[2] = 'ETHENA_CORRELATED_SPOKE';
+
+    spokes[3] = 0xba1B3D55D249692b669A164024A838309B7508AF;
+    names[3] = 'ETHENA_ECOSYSTEM_SPOKE';
+
+    spokes[4] = 0xD8B93635b8C6d0fF98CbE90b5988E3F2d1Cd9da1;
+    names[4] = 'FOREX_SPOKE';
+
+    spokes[5] = 0x65407b940966954b23dfA3caA5C0702bB42984DC;
+    names[5] = 'GOLD_SPOKE';
+
+    spokes[6] = 0x7EC68b5695e803e98a21a9A05d744F28b0a7753D;
+    names[6] = 'LOMBARD_BTC_SPOKE';
+
+    spokes[7] = 0xbF10BDfE177dE0336aFD7fcCF80A904E15386219;
+    names[7] = 'ETHERFI_ESPOKE';
+
+    spokes[8] = 0x3131FE68C4722e726fe6B2819ED68e514395B9a4;
+    names[8] = 'KELP_ESPOKE';
+
+    spokes[9] = 0xe1900480ac69f0B296841Cd01cC37546d92F35Cd;
+    names[9] = 'LIDO_ESPOKE';
+
+    address[] memory oldPms = new address[](2);
+    oldPms[0] = 0x6c044c0D3801499bCAbfAd458B70880bc518e9F7; // TAKER_POSITION_MANAGER
+    oldPms[1] = 0x51305839CE822a7b4b12AA7D86eA7005052d575c; // CONFIG_POSITION_MANAGER
+
+    // TODO: fill in once the new Position Managers
+    address[] memory newPms = new address[](2);
+    newPms[0] = address(0); // NEW_TAKER_POSITION_MANAGER
+    newPms[1] = address(0); // NEW_CONFIG_POSITION_MANAGER
+
+    return
+      ChainConfig({
+        chainId: 1,
+        accessManager: 0x08aE3BE30958cDd1847ec58fFfd4C451a87fDF01,
+        spokeConfigurator: 0x9BFFf48BFb5A7AE70c348d4d4cb97E8DEFa5389a,
+        spokes: spokes,
+        spokeNames: names,
+        oldPms: oldPms,
+        newPms: newPms,
+        grantRole400ToSafe: false
+      });
+  }
+
+  // ──────────────────────────── Avalanche ────────────────────────────
+
+  /// @dev The Safe does hold role 0 but not role 400.
+  ///      Role 0 gives the hability to grant the role to itself as the first
+  ///      action of the very same batch and the following calls already see it.
+  ///      3 Spokes x 2 Position Managers x 4 changes + 1 grant = 25 actions.
+  function avalanche() internal pure returns (ChainConfig memory cfg) {
+    address[] memory spokes = new address[](3);
+    string[] memory names = new string[](3);
+
+    spokes[0] = 0x435272CefF93a1E657E8ABfdf0A13e95900A3a56;
+    names[0] = 'MAIN_SPOKE';
+
+    spokes[1] = 0x6a37776B5E026dBdF043b4F933c323C84DD1B514;
+    names[1] = 'FOREX_SPOKE';
+
+    spokes[2] = 0x3b517594277c67307CF2d7CBE6FE1D4399B68c41;
+    names[2] = 'AVAX_CORRELATED_SPOKE';
+
+    address[] memory oldPms = new address[](2);
+    oldPms[0] = 0x5A5A711560eb9293Ef6F4bc33CD8589b4A603D10; // TAKER_POSITION_MANAGER
+    oldPms[1] = 0x50BE00C5EbF6CC230B8970f4205Cd0B5A70EaEB1; // CONFIG_POSITION_MANAGER
+
+    // TODO: fill in once the new Position Managers
+    address[] memory newPms = new address[](2);
+    newPms[0] = address(0); // NEW_TAKER_POSITION_MANAGER
+    newPms[1] = address(0); // NEW_CONFIG_POSITION_MANAGER
+
+    return
+      ChainConfig({
+        chainId: 43114,
+        accessManager: 0xe069096bDAfF9bAD15b2f1079EaF0f1685a24522,
+        spokeConfigurator: 0x8F72573F1Aa0A1e39fFD2a2A69e9EDAa8B982642,
+        spokes: spokes,
+        spokeNames: names,
+        oldPms: oldPms,
+        newPms: newPms,
+        grantRole400ToSafe: true
+      });
+  }
+
+  // ───────────────────────────── The batch ─────────────────────────────
+
+  /// @notice Builds the full batch for a chain.
+  /// @dev Four changes, in this order:
+  ///        1. Spoke side  — deactivate the old  (`updatePositionManager(spoke, old, false)`)
+  ///        2. PM side     — deregister the old  (`old.registerSpoke(spoke, false)`)
+  ///        3. Spoke side  — activate the new    (`updatePositionManager(spoke, new, true)`)
+  ///        4. PM side     — register the new    (`new.registerSpoke(spoke, true)`)
+  /// @param cfg The chain to build for.
+  /// @return actions The ordered action list.
+  function buildActions(ChainConfig memory cfg) internal pure returns (Action[] memory actions) {
+    require(
+      cfg.spokes.length == cfg.spokeNames.length,
+      LengthMismatch(cfg.spokes.length, cfg.spokeNames.length)
+    );
+    require(
+      cfg.oldPms.length == cfg.newPms.length,
+      LengthMismatch(cfg.oldPms.length, cfg.newPms.length)
+    );
+
+    uint256 grantCount = cfg.grantRole400ToSafe ? 1 : 0;
+    actions = new Action[](grantCount + cfg.spokes.length * cfg.oldPms.length * 4);
+    uint256 i;
+
+    // Must come first: every `updatePositionManager` below is `restricted` and would revert
+    // without the role. Safe inside the same transaction because the role's grant delay is
+    // zero, so the membership is effective immediately for the following calls.
+    if (cfg.grantRole400ToSafe) {
+      actions[i++] = Action({
+        to: cfg.accessManager,
+        data: abi.encodeCall(
+          IAccessManager.grantRole,
+          (SPOKE_CONFIGURATOR_DOMAIN_ADMIN_ROLE, PROTOCOL_SECURITY_COUNCIL, 0)
+        )
+      });
+    }
+
+    for (uint256 s; s < cfg.spokes.length; ++s) {
+      for (uint256 p; p < cfg.oldPms.length; ++p) {
+        actions[i++] = Action({
+          to: cfg.spokeConfigurator,
+          data: abi.encodeCall(
+            ISpokeConfigurator.updatePositionManager,
+            (cfg.spokes[s], cfg.oldPms[p], false)
+          )
+        });
+
+        actions[i++] = Action({
+          to: cfg.oldPms[p],
+          data: abi.encodeCall(IPositionManagerBase.registerSpoke, (cfg.spokes[s], false))
+        });
+
+        actions[i++] = Action({
+          to: cfg.spokeConfigurator,
+          data: abi.encodeCall(
+            ISpokeConfigurator.updatePositionManager,
+            (cfg.spokes[s], cfg.newPms[p], true)
+          )
+        });
+
+        actions[i++] = Action({
+          to: cfg.newPms[p],
+          data: abi.encodeCall(IPositionManagerBase.registerSpoke, (cfg.spokes[s], true))
+        });
+      }
+    }
+  }
+}

--- a/tests/deployments/fork/PositionManagersUpdateTest.t.sol
+++ b/tests/deployments/fork/PositionManagersUpdateTest.t.sol
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Test} from 'forge-std/Test.sol';
+import {console2 as console} from 'forge-std/console2.sol';
+
+import {ISpoke} from 'src/spoke/interfaces/ISpoke.sol';
+import {ISpokeConfigurator} from 'src/spoke/interfaces/ISpokeConfigurator.sol';
+import {IPositionManagerBase} from 'src/position-manager/interfaces/IPositionManagerBase.sol';
+import {IAccessManager} from 'src/dependencies/openzeppelin/IAccessManager.sol';
+import {Ownable2Step} from 'src/dependencies/openzeppelin/Ownable2Step.sol';
+
+import {
+  ChainConfig,
+  PositionManagersUpdateUtils
+} from 'scripts/utils/PositionManagersUpdateUtils.sol';
+
+/// @title PositionManagersUpdateTestBase
+/// @author Aave Labs
+/// @notice Simulates the Position Managers update batch on a mainnet fork, BEFORE it is signed.
+///
+/// @dev Executes exactly the action list that `PositionManagersUpdateJson.s.sol` emits, pranked as
+///      the Protocol Security Council Safe, and asserts the resulting handshake flags. The two
+///      artifacts share `PositionManagersUpdateUtils.buildActions`, so the file that gets signed
+///      is the one these tests exercised.
+abstract contract PositionManagersUpdateTestBase is Test {
+  /// @dev `ISpokeConfigurator.updatePositionManager(address,address,bool)`.
+  bytes4 internal constant UPDATE_PM_SELECTOR = 0x152ef832;
+
+  address internal user = makeAddr('USER');
+  address internal attacker = makeAddr('ATTACKER');
+
+  /// @dev Resolved new Position Manager addresses: the real ones if set, otherwise the mocks.
+  address[] internal newPms;
+
+  // ─────────────────────── Per-chain hooks ───────────────────────
+
+  function _chainConfig() internal pure virtual returns (ChainConfig memory);
+
+  /// @dev `rpc_endpoints` alias in foundry.toml.
+  function _rpcAlias() internal pure virtual returns (string memory);
+
+  /// @dev All five currently deployed Position Managers.
+  function _allCurrentPms() internal pure virtual returns (address[] memory);
+
+  /// @dev The Aave Labs Executor on this chain.
+  function _labsExecutor() internal pure virtual returns (address);
+
+  /// @dev Uses mocks for the PMs if the new addresses are not yet included in the PositonManagersUpdateUtils config.
+  function setUp() public virtual {
+    vm.createSelectFork(vm.rpcUrl(_rpcAlias()));
+
+    ChainConfig memory cfg = _chainConfig();
+    for (uint256 i; i < cfg.newPms.length; ++i) {
+      if (cfg.newPms[i] == address(0)) {
+        address mock = makeAddr(string.concat('NEW_PM_', vm.toString(i)));
+        _installMockPositionManager({target: mock, template: cfg.oldPms[i]});
+        newPms.push(mock);
+      } else {
+        newPms.push(cfg.newPms[i]);
+      }
+    }
+  }
+
+  /// @notice Used to mock the new PMs when not deployed yet using forge cheatcode `vm.etch` and `vm.store`.
+  function _installMockPositionManager(address target, address template) internal {
+    vm.etch(target, template.code);
+    vm.store(
+      target,
+      bytes32(0),
+      bytes32(uint256(uint160(PositionManagersUpdateUtils.PROTOCOL_SECURITY_COUNCIL)))
+    );
+    assertEq(
+      Ownable2Step(target).owner(),
+      PositionManagersUpdateUtils.PROTOCOL_SECURITY_COUNCIL,
+      'mock position manager: owner not set'
+    );
+  }
+
+  /// @dev The chain config with the resolved (real or mocked) new addresses.
+  function _cfg() internal view returns (ChainConfig memory cfg) {
+    cfg = _chainConfig();
+    cfg.newPms = newPms;
+  }
+
+  /// @dev Runs the batch exactly as the Safe will: sequential calls, one sender, one transaction.
+  function _executeBatch() internal {
+    PositionManagersUpdateUtils.Action[] memory actions = PositionManagersUpdateUtils.buildActions(
+      _cfg()
+    );
+
+    vm.startPrank(PositionManagersUpdateUtils.PROTOCOL_SECURITY_COUNCIL);
+    for (uint256 i; i < actions.length; ++i) {
+      (bool ok, bytes memory ret) = actions[i].to.call(actions[i].data);
+      if (!ok) {
+        console.log('batch failed at action [%s], target %s', i, actions[i].to);
+        revert(string(ret));
+      }
+    }
+    vm.stopPrank();
+  }
+
+  // ───────────────── Preconditions: no batch executed ─────────────────
+
+  /// @notice Nobody but the Safe can run either half of the batch.
+  function test_batch_revertsForUnauthorizedCaller() public {
+    ChainConfig memory cfg = _cfg();
+
+    vm.prank(attacker);
+    vm.expectRevert();
+    IPositionManagerBase(cfg.newPms[0]).registerSpoke(cfg.spokes[0], true);
+
+    vm.prank(attacker);
+    vm.expectRevert();
+    ISpokeConfigurator(cfg.spokeConfigurator).updatePositionManager(
+      cfg.spokes[0],
+      cfg.newPms[0],
+      true
+    );
+  }
+
+  /// @notice The Safe owns every Position Manager, so it can do the `registerSpoke` half.
+  function test_preconditions_safeOwnsPositionManagers() public view {
+    address[] memory pms = _allCurrentPms();
+    for (uint256 i; i < pms.length; ++i) {
+      assertEq(
+        Ownable2Step(pms[i]).owner(),
+        PositionManagersUpdateUtils.PROTOCOL_SECURITY_COUNCIL,
+        'position manager owner is not the Safe'
+      );
+      assertEq(Ownable2Step(pms[i]).pendingOwner(), address(0), 'an ownership transfer is pending');
+    }
+  }
+
+  /// @notice Demonstrate why we need to run the batch in the Safe's context and not use the Labs Executor.
+  /// @dev The Labs Executor holds role 400 but is not the Position Manager owner, so a payload
+  ///      running in the Executor's context would revert on every `registerSpoke`.
+  function test_preconditions_executorCannotRegisterSpokes() public view {
+    ChainConfig memory cfg = _chainConfig();
+    for (uint256 i; i < cfg.oldPms.length; ++i) {
+      assertNotEq(
+        Ownable2Step(cfg.oldPms[i]).owner(),
+        _labsExecutor(),
+        'the Executor owns the position managers: reconsider the payload route'
+      );
+    }
+  }
+
+  /// @notice The Safe can reach the Spoke side, either already or via the grant in the batch.
+  function test_preconditions_safeCanConfigureSpokes() public view {
+    ChainConfig memory cfg = _chainConfig();
+    IAccessManager am = IAccessManager(cfg.accessManager);
+
+    (bool canCall, uint32 delay) = am.canCall(
+      PositionManagersUpdateUtils.PROTOCOL_SECURITY_COUNCIL,
+      cfg.spokeConfigurator,
+      UPDATE_PM_SELECTOR
+    );
+
+    if (cfg.grantRole400ToSafe) {
+      // The batch grants the role to itself as action [0]. That only works because the role's
+      // grant delay is zero, so the membership is live for the calls that follow in the same
+      // transaction. If someone sets a delay later, this assert goes red instead of the batch
+      // reverting on-chain with signatures already collected.
+      assertFalse(canCall, 'grantRole400ToSafe is set but the Safe already has the role');
+      assertEq(
+        am.getRoleGrantDelay(PositionManagersUpdateUtils.SPOKE_CONFIGURATOR_DOMAIN_ADMIN_ROLE),
+        0,
+        'role 400 has a grant delay: the batch cannot be atomic'
+      );
+      (bool isAdmin, uint32 adminDelay) = am.hasRole(
+        0,
+        PositionManagersUpdateUtils.PROTOCOL_SECURITY_COUNCIL
+      );
+      assertTrue(isAdmin, 'the Safe cannot grant itself role 400');
+      assertEq(adminDelay, 0, 'the Safe has an execution delay on the admin role');
+      assertEq(
+        am.getRoleAdmin(PositionManagersUpdateUtils.SPOKE_CONFIGURATOR_DOMAIN_ADMIN_ROLE),
+        0,
+        'role 400 is not administered by the admin role'
+      );
+    } else {
+      assertTrue(canCall, 'the Safe cannot call SpokeConfigurator.updatePositionManager');
+      assertEq(delay, 0, 'the Safe has an execution delay: the batch would not be immediate');
+    }
+  }
+
+  /// @notice Baseline to preserve: every current Position Manager is wired on every Spoke.
+  function test_preconditions_currentWiringIsSymmetric() public view {
+    ChainConfig memory cfg = _chainConfig();
+    address[] memory pms = _allCurrentPms();
+
+    for (uint256 s; s < cfg.spokes.length; ++s) {
+      for (uint256 p; p < pms.length; ++p) {
+        assertTrue(
+          ISpoke(cfg.spokes[s]).isPositionManagerActive(pms[p]),
+          string.concat('Spoke side not active on ', cfg.spokeNames[s])
+        );
+        assertTrue(
+          IPositionManagerBase(pms[p]).isSpokeRegistered(cfg.spokes[s]),
+          string.concat('PM side not registered on ', cfg.spokeNames[s])
+        );
+      }
+    }
+  }
+
+  /// @notice The new Position Managers start completely unwired.
+  function test_preconditions_newPositionManagersAreUnwired() public view {
+    ChainConfig memory cfg = _cfg();
+    for (uint256 s; s < cfg.spokes.length; ++s) {
+      for (uint256 p; p < cfg.newPms.length; ++p) {
+        assertFalse(ISpoke(cfg.spokes[s]).isPositionManagerActive(cfg.newPms[p]));
+        assertFalse(IPositionManagerBase(cfg.newPms[p]).isSpokeRegistered(cfg.spokes[s]));
+      }
+    }
+  }
+
+  // ───────────────────────── After the batch ─────────────────────────
+
+  /// @notice Both sides of the handshake are set for every new Position Manager on every Spoke.
+  function test_batch_handshakeIsComplete() public {
+    _executeBatch();
+
+    ChainConfig memory cfg = _cfg();
+    uint256 pairs;
+    for (uint256 s; s < cfg.spokes.length; ++s) {
+      for (uint256 p; p < cfg.newPms.length; ++p) {
+        assertTrue(
+          ISpoke(cfg.spokes[s]).isPositionManagerActive(cfg.newPms[p]),
+          string.concat('new PM inactive on ', cfg.spokeNames[s])
+        );
+        assertTrue(
+          IPositionManagerBase(cfg.newPms[p]).isSpokeRegistered(cfg.spokes[s]),
+          string.concat('new PM unregistered on ', cfg.spokeNames[s])
+        );
+        ++pairs;
+      }
+    }
+    assertEq(pairs, cfg.spokes.length * cfg.newPms.length, 'unexpected pair count');
+  }
+
+  /// @notice The two replaced Position Managers are off on both sides.
+  function test_batch_replacedPositionManagersAreOff() public {
+    _executeBatch();
+
+    ChainConfig memory cfg = _cfg();
+    for (uint256 s; s < cfg.spokes.length; ++s) {
+      for (uint256 p; p < cfg.oldPms.length; ++p) {
+        assertFalse(
+          ISpoke(cfg.spokes[s]).isPositionManagerActive(cfg.oldPms[p]),
+          string.concat('old PM still active on ', cfg.spokeNames[s])
+        );
+        assertFalse(
+          IPositionManagerBase(cfg.oldPms[p]).isSpokeRegistered(cfg.spokes[s]),
+          string.concat('old PM still registered on ', cfg.spokeNames[s])
+        );
+      }
+    }
+  }
+
+  /// @notice The three Position Managers that do not change are untouched.
+  /// @dev Giver, NativeTokenGateway and SignatureGateway are byte-identical between v0.5.11 and
+  ///      main, so they keep their CREATE2 address and must not appear in the batch at all.
+  function test_batch_unchangedPositionManagersAreUntouched() public {
+    _executeBatch();
+
+    ChainConfig memory cfg = _cfg();
+    address[] memory all = _allCurrentPms();
+
+    for (uint256 s; s < cfg.spokes.length; ++s) {
+      for (uint256 a; a < all.length; ++a) {
+        if (_contains(cfg.oldPms, all[a])) continue;
+        assertTrue(
+          ISpoke(cfg.spokes[s]).isPositionManagerActive(all[a]),
+          string.concat('an unchanged PM was deactivated on ', cfg.spokeNames[s])
+        );
+        assertTrue(
+          IPositionManagerBase(all[a]).isSpokeRegistered(cfg.spokes[s]),
+          string.concat('an unchanged PM was deregistered on ', cfg.spokeNames[s])
+        );
+      }
+    }
+  }
+
+  /// @notice On chains that need it, the batch leaves the Safe holding role 400.
+  function test_batch_roleGrantOutcome() public {
+    ChainConfig memory cfg = _chainConfig();
+    _executeBatch();
+
+    (bool canCall, ) = IAccessManager(cfg.accessManager).canCall(
+      PositionManagersUpdateUtils.PROTOCOL_SECURITY_COUNCIL,
+      cfg.spokeConfigurator,
+      UPDATE_PM_SELECTOR
+    );
+    assertTrue(canCall, 'the Safe should be able to configure spokes after the batch');
+  }
+
+  /// @notice Re-running the batch changes nothing.
+  /// @dev Matters because a Safe transaction can be re-proposed or retried.
+  function test_batch_isIdempotent() public {
+    _executeBatch();
+    _executeBatch();
+
+    ChainConfig memory cfg = _cfg();
+    assertTrue(ISpoke(cfg.spokes[0]).isPositionManagerActive(cfg.newPms[0]));
+    assertTrue(IPositionManagerBase(cfg.newPms[0]).isSpokeRegistered(cfg.spokes[0]));
+    assertFalse(ISpoke(cfg.spokes[0]).isPositionManagerActive(cfg.oldPms[0]));
+  }
+
+  /// @notice Prints the batch for eyeball review.
+  function test_logBatch() public view {
+    PositionManagersUpdateUtils.Action[] memory actions = PositionManagersUpdateUtils.buildActions(
+      _cfg()
+    );
+    console.log('chain %s: %s actions', block.chainid, actions.length);
+    for (uint256 i; i < actions.length; ++i) {
+      console.log('  [%s] target %s', i, actions[i].to);
+    }
+  }
+
+  function _contains(address[] memory haystack, address needle) private pure returns (bool) {
+    for (uint256 i; i < haystack.length; ++i) if (haystack[i] == needle) return true;
+    return false;
+  }
+}
+
+/// @notice Ethereum. 10 Spokes x 2 Position Managers x 4 changes = 80 actions, no role grant.
+/// @dev forge test --match-contract PositionManagersUpdateEthereumTest -vv
+contract PositionManagersUpdateEthereumTest is PositionManagersUpdateTestBase {
+  function _chainConfig() internal pure override returns (ChainConfig memory) {
+    return PositionManagersUpdateUtils.ethereum();
+  }
+
+  function _rpcAlias() internal pure override returns (string memory) {
+    return 'mainnet';
+  }
+
+  function _allCurrentPms() internal pure override returns (address[] memory pms) {
+    pms = new address[](5);
+    pms[0] = 0x17A54b8d6D9C68e7fa1C7112AC998EA1BA51d11e; // GIVER_POSITION_MANAGER
+    pms[1] = 0x6c044c0D3801499bCAbfAd458B70880bc518e9F7; // TAKER_POSITION_MANAGER
+    pms[2] = 0x51305839CE822a7b4b12AA7D86eA7005052d575c; // CONFIG_POSITION_MANAGER
+    pms[3] = 0xe68ab4F90Fe026B9873F5F276eD2d7efBbbE42Be; // NATIVE_TOKEN_GATEWAY
+    pms[4] = 0xfbC184337Dc6595D8bf62968Bda46e7De7AF9c3d; // SIGNATURE_GATEWAY
+  }
+
+  function _labsExecutor() internal pure override returns (address) {
+    return 0x14339e2178A954d5FB839D5Ff31644fE0F25F517;
+  }
+}
+
+/// @notice Avalanche. 1 role grant + 3 Spokes x 2 Position Managers x 4 changes = 25 actions.
+/// @dev forge test --match-contract PositionManagersUpdateAvalancheTest -vv
+contract PositionManagersUpdateAvalancheTest is PositionManagersUpdateTestBase {
+  function _chainConfig() internal pure override returns (ChainConfig memory) {
+    return PositionManagersUpdateUtils.avalanche();
+  }
+
+  function _rpcAlias() internal pure override returns (string memory) {
+    return 'avalanche';
+  }
+
+  function _allCurrentPms() internal pure override returns (address[] memory pms) {
+    pms = new address[](5);
+    pms[0] = 0x50c4C40aB6BaE46B372a251BEacE388439aa96b4; // GIVER_POSITION_MANAGER
+    pms[1] = 0x5A5A711560eb9293Ef6F4bc33CD8589b4A603D10; // TAKER_POSITION_MANAGER
+    pms[2] = 0x50BE00C5EbF6CC230B8970f4205Cd0B5A70EaEB1; // CONFIG_POSITION_MANAGER
+    pms[3] = 0xE4C7183A5f22c365140F41d733d8A8baD5A1a6bA; // NATIVE_TOKEN_GATEWAY
+    pms[4] = 0x6E3B91A951DA9b515a5E98F0c7D210a697382e7F; // SIGNATURE_GATEWAY
+  }
+
+  function _labsExecutor() internal pure override returns (address) {
+    return 0xb619fA61e795D47f517702e63ce50292370561F1;
+  }
+}

--- a/tests/deployments/fork/PositionManagersUpdateVerificationTest.t.sol
+++ b/tests/deployments/fork/PositionManagersUpdateVerificationTest.t.sol
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Test} from 'forge-std/Test.sol';
+
+import {ISpoke} from 'src/spoke/interfaces/ISpoke.sol';
+import {IPositionManagerBase} from 'src/position-manager/interfaces/IPositionManagerBase.sol';
+import {IAccessManager} from 'src/dependencies/openzeppelin/IAccessManager.sol';
+import {Ownable2Step} from 'src/dependencies/openzeppelin/Ownable2Step.sol';
+
+import {
+  ChainConfig,
+  PositionManagersUpdateUtils
+} from 'scripts/utils/PositionManagersUpdateUtils.sol';
+
+/// @title PositionManagersUpdateVerificationTestBase
+/// @author Aave Labs
+/// @notice Verifies the post-state of a devnet where the Protocol Security Council Safe has
+///         ALREADY executed the Position Managers update batch.
+/// @dev Skipped unless the devnet RPC is set, so it never breaks CI for anyone without one.
+abstract contract PositionManagersUpdateVerificationTestBase is Test {
+  /// @dev `ISpokeConfigurator.updatePositionManager(address,address,bool)`.
+  bytes4 internal constant UPDATE_PM_SELECTOR = 0x152ef832;
+
+  bool internal devnetAvailable;
+
+  modifier onlyDevnet() {
+    vm.skip(!devnetAvailable, string.concat(_devnetEnvVar(), ' not set'));
+    _;
+  }
+
+  // ─────────────────────── Per-chain hooks ───────────────────────
+
+  function _chainConfig() internal pure virtual returns (ChainConfig memory);
+
+  /// @dev Env var holding the Tenderly devnet RPC for this chain. One devnet per chain.
+  function _devnetEnvVar() internal pure virtual returns (string memory);
+
+  /// @dev All five currently deployed Position Managers.
+  function _allPreviousPms() internal pure virtual returns (address[] memory);
+
+  function setUp() public virtual {
+    string memory rpc = vm.envOr(_devnetEnvVar(), string(''));
+    if (bytes(rpc).length == 0) return;
+
+    vm.createSelectFork(rpc);
+    devnetAvailable = true;
+
+    // Guards against pointing at the wrong devnet.
+    assertEq(block.chainid, _chainConfig().chainId, 'devnet is on the wrong chain');
+  }
+
+  // ─────────────────────── Batch preconditions ───────────────────────
+
+  /// @notice The deployed Position Managers are owned by the Safe.
+  function test_newPositionManagers_ownedBySafe() public onlyDevnet {
+    ChainConfig memory cfg = _chainConfig();
+    address[] memory newPms = cfg.newPms;
+
+    for (uint256 i; i < newPms.length; ++i) {
+      assertGt(newPms[i].code.length, 0, 'new position manager has no code');
+      assertEq(
+        Ownable2Step(newPms[i]).owner(),
+        PositionManagersUpdateUtils.PROTOCOL_SECURITY_COUNCIL,
+        'new position manager is not owned by the Safe'
+      );
+      assertEq(
+        Ownable2Step(newPms[i]).pendingOwner(),
+        address(0),
+        'an ownership transfer is pending on a new position manager'
+      );
+      assertNotEq(newPms[i], cfg.oldPms[i], 'new address equals the old one');
+    }
+  }
+
+  /// @notice On Avalanche the batch grants the Safe role 400, as it needs it to configure the Spokes. We test that after the batch in all the chains the Safe have the 400 role.
+  function test_batchWasExecuted_safeCanConfigureSpokes() public onlyDevnet {
+    ChainConfig memory cfg = _chainConfig();
+    IAccessManager am = IAccessManager(cfg.accessManager);
+
+    (bool canCall, uint32 delay) = am.canCall(
+      PositionManagersUpdateUtils.PROTOCOL_SECURITY_COUNCIL,
+      cfg.spokeConfigurator,
+      UPDATE_PM_SELECTOR
+    );
+    assertTrue(canCall, 'the Safe cannot configure spokes after the batch');
+    assertEq(delay, 0, 'the Safe ended up with an execution delay');
+
+    (bool isMember, uint32 memberDelay) = am.hasRole(
+      PositionManagersUpdateUtils.SPOKE_CONFIGURATOR_DOMAIN_ADMIN_ROLE,
+      PositionManagersUpdateUtils.PROTOCOL_SECURITY_COUNCIL
+    );
+    assertTrue(isMember, 'the Safe does not hold role 400');
+    assertEq(memberDelay, 0, 'role 400 carries an execution delay');
+  }
+
+  function _contains(address[] memory haystack, address needle) private pure returns (bool) {
+    for (uint256 i; i < haystack.length; ++i) if (haystack[i] == needle) return true;
+    return false;
+  }
+
+  // ─────────────────────── Batch outcome ───────────────────────
+
+  /// @notice Both sides of the handshake are set for the new Position Managers on every Spoke.
+  function test_batchWasExecuted_handshakeIsComplete() public onlyDevnet {
+    ChainConfig memory cfg = _chainConfig();
+    address[] memory newPms = cfg.newPms;
+
+    for (uint256 s; s < cfg.spokes.length; ++s) {
+      for (uint256 p; p < newPms.length; ++p) {
+        assertTrue(
+          ISpoke(cfg.spokes[s]).isPositionManagerActive(newPms[p]),
+          string.concat('new PM not active on ', cfg.spokeNames[s])
+        );
+        assertTrue(
+          IPositionManagerBase(newPms[p]).isSpokeRegistered(cfg.spokes[s]),
+          string.concat('new PM not registered on ', cfg.spokeNames[s])
+        );
+      }
+    }
+  }
+
+  /// @notice The two replaced Position Managers are off on both sides.
+  /// @dev Their per-user approvals survive in the Spoke's storage but are inert while `active` is
+  ///      false. Clearing those would need `renouncePositionManagerRole` per user, which does not
+  ///      scale and is out of scope here.
+  function test_batchWasExecuted_replacedPositionManagersAreOff() public onlyDevnet {
+    ChainConfig memory cfg = _chainConfig();
+
+    for (uint256 s; s < cfg.spokes.length; ++s) {
+      for (uint256 p; p < cfg.oldPms.length; ++p) {
+        assertFalse(
+          ISpoke(cfg.spokes[s]).isPositionManagerActive(cfg.oldPms[p]),
+          string.concat('old PM still active on ', cfg.spokeNames[s])
+        );
+        assertFalse(
+          IPositionManagerBase(cfg.oldPms[p]).isSpokeRegistered(cfg.spokes[s]),
+          string.concat('old PM still registered on ', cfg.spokeNames[s])
+        );
+      }
+    }
+  }
+
+  /// @notice The three Position Managers that keep their address are untouched.
+  /// @dev Giver, NativeTokenGateway and SignatureGateway are byte-identical between v0.5.11 and
+  ///      main, so they must not appear in the batch at all. This is the scope check.
+  function test_batchWasExecuted_unchangedPositionManagersAreUntouched() public onlyDevnet {
+    ChainConfig memory cfg = _chainConfig();
+    address[] memory all = _allPreviousPms();
+
+    for (uint256 s; s < cfg.spokes.length; ++s) {
+      for (uint256 a; a < all.length; ++a) {
+        if (_contains(cfg.oldPms, all[a])) continue;
+        assertTrue(
+          ISpoke(cfg.spokes[s]).isPositionManagerActive(all[a]),
+          string.concat('an unchanged PM was deactivated on ', cfg.spokeNames[s])
+        );
+        assertTrue(
+          IPositionManagerBase(all[a]).isSpokeRegistered(cfg.spokes[s]),
+          string.concat('an unchanged PM was deregistered on ', cfg.spokeNames[s])
+        );
+      }
+    }
+  }
+}
+
+/// @notice Ethereum devnet.
+/// @dev TENDERLY_DEVNET_RPC_MAINNET=… forge test --match-contract PositionManagersUpdateVerificationEthereumTest -vv
+contract PositionManagersUpdateVerificationEthereumTest is
+  PositionManagersUpdateVerificationTestBase
+{
+  function _chainConfig() internal pure override returns (ChainConfig memory) {
+    return PositionManagersUpdateUtils.ethereum();
+  }
+
+  function _devnetEnvVar() internal pure override returns (string memory) {
+    return 'TENDERLY_DEVNET_RPC_MAINNET';
+  }
+
+  function _allPreviousPms() internal pure override returns (address[] memory pms) {
+    pms = new address[](5);
+    pms[0] = 0x17A54b8d6D9C68e7fa1C7112AC998EA1BA51d11e; // GIVER_POSITION_MANAGER
+    pms[1] = 0x6c044c0D3801499bCAbfAd458B70880bc518e9F7; // TAKER_POSITION_MANAGER
+    pms[2] = 0x51305839CE822a7b4b12AA7D86eA7005052d575c; // CONFIG_POSITION_MANAGER
+    pms[3] = 0xe68ab4F90Fe026B9873F5F276eD2d7efBbbE42Be; // NATIVE_TOKEN_GATEWAY
+    pms[4] = 0xfbC184337Dc6595D8bf62968Bda46e7De7AF9c3d; // SIGNATURE_GATEWAY
+  }
+}
+
+/// @notice Avalanche devnet. The batch here also grants the Safe role 400 as its first action.
+/// @dev TENDERLY_DEVNET_RPC_AVALANCHE=… forge test --match-contract PositionManagersUpdateVerificationAvalancheTest -vv
+contract PositionManagersUpdateVerificationAvalancheTest is
+  PositionManagersUpdateVerificationTestBase
+{
+  function _chainConfig() internal pure override returns (ChainConfig memory) {
+    return PositionManagersUpdateUtils.avalanche();
+  }
+
+  function _devnetEnvVar() internal pure override returns (string memory) {
+    return 'TENDERLY_DEVNET_RPC_AVALANCHE';
+  }
+
+  function _allPreviousPms() internal pure override returns (address[] memory pms) {
+    pms = new address[](5);
+    pms[0] = 0x50c4C40aB6BaE46B372a251BEacE388439aa96b4; // GIVER_POSITION_MANAGER
+    pms[1] = 0x5A5A711560eb9293Ef6F4bc33CD8589b4A603D10; // TAKER_POSITION_MANAGER
+    pms[2] = 0x50BE00C5EbF6CC230B8970f4205Cd0B5A70EaEB1; // CONFIG_POSITION_MANAGER
+    pms[3] = 0xE4C7183A5f22c365140F41d733d8A8baD5A1a6bA; // NATIVE_TOKEN_GATEWAY
+    pms[4] = 0x6E3B91A951DA9b515a5E98F0c7D210a697382e7F; // SIGNATURE_GATEWAY
+  }
+}


### PR DESCRIPTION
## Review only — not for merge

### Context

The Position Managers currently deployed on-chain come from `v0.5.11`. Since then, **TakerPositionManager** and **ConfigPositionManager** have changed in `main` and need to be updated. 
PRs : https://github.com/aave/aave-v4/pull/1281 and https://github.com/aave/aave-v4/pull/1279

The new PMs are **not deployed yet**, so this PR prepares the execution flow and tests ahead of deployment.

### Execution through the Safe

The Aave Executor is not — and will not be — the owner of the Position Managers. Therefore, the update cannot be executed through the an `AaveV4Payload` and must be executed directly by the `PROTOCOL_SECURITY_COUNCIL` Safe.

This has already been confirmed with Miguel.

### What this PR adds

- `PositionManagersUpdateUtils.sol`: defines the actions required for the PM migration.
- A script that generates the **Safe Transaction Builder JSON** from those actions.
- Tests against the **same generated actions/calldata**, ensuring that what is exported to the Safe is exactly what has been tested.

### Tests

Two levels of testing are included:

1. **Fork tests:** simulate the full Safe batch execution on Ethereum and Avalanche. Until the new PMs are deployed, they are mocked to allow E2E testing.
2. **Tenderly Devnet verification:** verifies the final state on a devnet where the batch has already been executed. These tests self-skip if `TENDERLY_DEVNET_RPC_MAINNET` / `TENDERLY_DEVNET_RPC_AVALANCHE` are not provided.

### Execution scope

- **Ethereum:** 80 actions
- **Avalanche:** 25 actions

> **Avalanche:** The Safe needs to grant itself **role 400** before it can attach the new PMs to the Spokes. This is included as an additional action in the batch.

### ⚠️ Blocking TODO

The new PM addresses still need to be added to `PositionManagersUpdateUtils.sol` once they are deployed.

Until those addresses are configured, **the JSON generation script intentionally reverts** to prevent generating an invalid Safe payload.

