### PR TITLE
fix: remove obsolete PR comment secret

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -17,5 +17,3 @@ permissions:
 jobs:
   comment:
     uses: aave-dao/github-workflows/.github/workflows/comment.yml@main
-    secrets:
-      READ_ONLY_PAT: ${{ secrets.READ_ONLY_PAT }}


### PR DESCRIPTION
The shared `aave-dao/github-workflows` comment workflow no longer declares `READ_ONLY_PAT`, so explicitly passing it causes the PR Comment workflow to fail at startup.

Remove the obsolete secret mapping and its empty block. The shared publisher already uses `github.token`; other credentials, permissions, and workflow behavior are unchanged.