### PR TITLE
chore: mutation testing survivor report

### DIFF
--- a/reports/mutation-survivors.json
+++ b/reports/mutation-survivors.json
@@ -17,7 +17,7 @@
     "never",
     "-vv"
   ],
-  "updated": "2026-09-08T16:25:13.145166+00:00",
+  "updated": "2026-09-08T16:26:58.574581+00:00",
   "summary": {
     "filesCompleted": 2,
     "totalFiles": 177,

--- a/reports/mutation-survivors.json
+++ b/reports/mutation-survivors.json
@@ -17,16 +17,16 @@
     "never",
     "-vv"
   ],
-  "updated": "2026-09-08T16:26:58.574581+00:00",
+  "updated": "2026-09-08T16:41:11.774552+00:00",
   "summary": {
-    "filesCompleted": 2,
+    "filesCompleted": 5,
     "totalFiles": 177,
-    "mutationScorePct": 94.9,
-    "killed": 131,
-    "survived": 7,
-    "invalid": 19,
-    "skipped": 20,
-    "timedOut": 0
+    "mutationScorePct": 93.0,
+    "killed": 172,
+    "survived": 13,
+    "invalid": 45,
+    "skipped": 40,
+    "timedOut": 23
   },
   "survivors": [
     {
@@ -98,6 +98,66 @@
       "classification": "coverage-gap",
       "rationale": "Same as line 91: distinguishable only when mod(d, c) >= 2^255 (requires c > 2^255 and a*b wrapping into that range). Practically unreachable by random fuzzing; the original code is correct.",
       "killCondition": "Directed edge test with c > 2^255 and a*b chosen so (a*b) % c >= 2^255."
+    },
+    {
+      "file": "src/access/AccessManagerEnumerable.sol",
+      "line": 356,
+      "function": "_trackRoleLabel",
+      "original": "bytes(oldLabel).length > 0",
+      "mutated": "bytes(oldLabel).length != 0",
+      "classification": "equivalent",
+      "rationale": "Byte array length is an unsigned integer; length > 0 and length != 0 are the same predicate.",
+      "killCondition": "None. Provably unkillable."
+    },
+    {
+      "file": "src/access/AccessManagerEnumerable.sol",
+      "line": 318,
+      "function": "_trackRole",
+      "original": "roleId == PUBLIC_ROLE",
+      "mutated": "roleId >= PUBLIC_ROLE",
+      "classification": "equivalent",
+      "rationale": "PUBLIC_ROLE = type(uint64).max. For unsigned integers, x >= type(uint64).max is true exactly when x == type(uint64).max. Identical behavior.",
+      "killCondition": "None. Provably unkillable."
+    },
+    {
+      "file": "src/access/AccessManagerEnumerable.sol",
+      "line": 318,
+      "function": "_trackRole",
+      "original": "roleId == ADMIN_ROLE",
+      "mutated": "roleId <= ADMIN_ROLE",
+      "classification": "equivalent",
+      "rationale": "ADMIN_ROLE = type(uint64).min = 0. For unsigned integers, x <= 0 is true exactly when x == 0, so the mutated condition is identical to the original.",
+      "killCondition": "None. Provably unkillable."
+    },
+    {
+      "file": "src/access/AccessManagerEnumerable.sol",
+      "line": 386,
+      "function": "_trackRoleTargetSelector",
+      "original": "_roleToTargetToSelectorSet[oldRoleId][target].length() == 0",
+      "mutated": "_roleToTargetToSelectorSet[oldRoleId][target].length() <= 0",
+      "classification": "equivalent",
+      "rationale": "EnumerableSet length() returns uint256; length == 0 and length <= 0 are the same predicate for unsigned values.",
+      "killCondition": "None. Provably unkillable."
+    },
+    {
+      "file": "src/access/AccessManagerEnumerable.sol",
+      "line": 391,
+      "function": "_trackRoleTargetSelector",
+      "original": "roleId != ADMIN_ROLE",
+      "mutated": "roleId > ADMIN_ROLE",
+      "classification": "equivalent",
+      "rationale": "ADMIN_ROLE = 0. For unsigned integers, x != 0 and x > 0 are the same predicate.",
+      "killCondition": "None. Provably unkillable."
+    },
+    {
+      "file": "src/access/AccessManagerEnumerable.sol",
+      "line": 391,
+      "function": "_trackRoleTargetSelector",
+      "original": "roleId != ADMIN_ROLE",
+      "mutated": "roleId >= ADMIN_ROLE",
+      "classification": "coverage-gap",
+      "rationale": "roleId >= 0 is always true for uint64, so the mutant tracks targets/selectors even when roleId is ADMIN_ROLE (0), which the contract documents as excluded from tracking. The distinguishing input is setTargetFunctionRole with roleId = ADMIN_ROLE followed by a read of the role-0 enumeration getters; the suite never exercises that combination. The original code is correct.",
+      "killCondition": "Directed test: call setTargetFunctionRole(target, selector, ADMIN_ROLE), then assert getRoleTargetCount(ADMIN_ROLE) == 0 (or equivalent role-0 getters remain empty)."
     }
   ]
 }

--- a/reports/mutation-survivors.json
+++ b/reports/mutation-survivors.json
@@ -1,0 +1,103 @@
+{
+  "campaign": "2026-09-08-2524fe40",
+  "commit": "2524fe4018a42750300e114f2a8c4355df62a878",
+  "forgeVersion": "forge Version: 1.8.1",
+  "flags": [
+    "--mutation-jobs",
+    "4",
+    "--mutation-timeout",
+    "600",
+    "--mutation-optimizer-runs",
+    "200",
+    "--fuzz-runs",
+    "1000",
+    "--fuzz-seed",
+    "0x640",
+    "--color",
+    "never",
+    "-vv"
+  ],
+  "updated": "2026-09-08T16:25:13.145166+00:00",
+  "summary": {
+    "filesCompleted": 2,
+    "totalFiles": 177,
+    "mutationScorePct": 94.9,
+    "killed": 131,
+    "survived": 7,
+    "invalid": 19,
+    "skipped": 20,
+    "timedOut": 0
+  },
+  "survivors": [
+    {
+      "file": "src/libraries/math/MathUtils.sol",
+      "line": 25,
+      "function": "calculateLinearInterest",
+      "original": "gt(lastUpdateTimestamp, timestamp())",
+      "mutated": "sgt(lastUpdateTimestamp, timestamp())",
+      "classification": "equivalent",
+      "rationale": "gt and sgt differ only when an operand has bit 255 set. lastUpdateTimestamp is uint40 and block timestamps cannot approach 2^255, so both opcodes agree on every reachable input.",
+      "killCondition": "None. Only a meaningless vm.warp(2^255) test would distinguish them."
+    },
+    {
+      "file": "src/libraries/math/MathUtils.sol",
+      "line": 36,
+      "function": "min",
+      "original": "mul(xor(a, b), lt(a, b))",
+      "mutated": "div(xor(a, b), lt(a, b))",
+      "classification": "equivalent",
+      "rationale": "The second operand is boolean. When lt(a,b)=1: x*1 = x/1. When lt(a,b)=0: x*0 = 0 and EVM div(x,0) returns 0 rather than reverting. Identical for all inputs.",
+      "killCondition": "None. Provably unkillable."
+    },
+    {
+      "file": "src/libraries/math/MathUtils.sol",
+      "line": 91,
+      "function": "divUp",
+      "original": "gt(mod(a, b), 0)",
+      "mutated": "sgt(mod(a, b), 0)",
+      "classification": "coverage-gap",
+      "rationale": "Distinguishable only when mod(a, b) >= 2^255, which requires a divisor above 2^255. The fuzz domain includes such inputs but the sampling probability is ~2^-255 per run, so 1,000 runs never hit it. The original code is correct.",
+      "killCondition": "Directed edge test, e.g. assertEq(MathUtils.divUp(2**255, 2**255 + 1), 2)."
+    },
+    {
+      "file": "src/libraries/math/MathUtils.sol",
+      "line": 104,
+      "function": "mulDivDown",
+      "original": "or(iszero(b), iszero(gt(a, div(not(0), b))))",
+      "mutated": "xor(iszero(b), iszero(gt(a, div(not(0), b))))",
+      "classification": "coverage-gap",
+      "rationale": "or and xor differ only when both operands are 1, i.e. b = 0 (iszero(b)=1) and a = 0 (div(max,0)=0, so iszero(gt(a,0))=1). For mulDivDown(0, 0, c!=0) the original returns 0 while the mutant reverts. test_mulDivDown_ZeroAOrB covers (0,10,5) and (10,0,5) but not (0,0,c), and random fuzzing never draws 0 and 0 simultaneously. The original code is correct. mulDivUp line 120 has the identical guard with the same gap.",
+      "killCondition": "Directed edge tests: assertEq(MathUtils.mulDivDown(0, 0, 5), 0) and assertEq(MathUtils.mulDivUp(0, 0, 5), 0)."
+    },
+    {
+      "file": "src/libraries/math/MathUtils.sol",
+      "line": 43,
+      "function": "zeroFloorSub",
+      "original": "mul(sub(a, b), gt(a, b))",
+      "mutated": "div(sub(a, b), gt(a, b))",
+      "classification": "equivalent",
+      "rationale": "Same pattern as line 36: boolean second operand, and EVM division by zero returns 0. x*1 = x/1 and x*0 = div(x,0) = 0 for all inputs.",
+      "killCondition": "None. Provably unkillable."
+    },
+    {
+      "file": "src/libraries/math/MathUtils.sol",
+      "line": 50,
+      "function": "add",
+      "original": "b >= 0",
+      "mutated": "b > 0",
+      "classification": "equivalent",
+      "rationale": "Differs only at b = 0: the original returns a + uint256(0), the mutant returns a - uint256(-0); both equal a. test_add_edge_cases already exercises b = 0 and cannot distinguish them.",
+      "killCondition": "None. Provably unkillable."
+    },
+    {
+      "file": "src/libraries/math/MathUtils.sol",
+      "line": 125,
+      "function": "mulDivUp",
+      "original": "gt(mod(d, c), 0)",
+      "mutated": "sgt(mod(d, c), 0)",
+      "classification": "coverage-gap",
+      "rationale": "Same as line 91: distinguishable only when mod(d, c) >= 2^255 (requires c > 2^255 and a*b wrapping into that range). Practically unreachable by random fuzzing; the original code is correct.",
+      "killCondition": "Directed edge test with c > 2^255 and a*b chosen so (a*b) % c >= 2^255."
+    }
+  ]
+}


### PR DESCRIPTION
Living report of surviving mutants from the resumable mutation-testing campaign against commit 2524fe40 (full test suite per source file, 1,000 fuzz runs, seed 0x640).

`reports/mutation-survivors.json` is regenerated and pushed as each of the 177 source-file chunks completes. No production code changes.

Each survivor is classified as:
- **equivalent** — provably identical behavior on all reachable inputs; unkillable
- **coverage-gap** — a distinguishing input exists but the suite never exercises it; a directed test would kill it
- **tooling-artifact** — caused by the mutation runner
- **bug** — a genuine defect (none found so far)

Current state: 2/177 files, 94.9% mutation score, 7 survivors (all in `MathUtils.sol`: 4 equivalent, 3 coverage-gap, 0 bugs).